### PR TITLE
Fixed crash because of out of bound indices for MaxiCode.

### DIFF
--- a/src/common/bit_matrix.rs
+++ b/src/common/bit_matrix.rs
@@ -255,7 +255,7 @@ impl BitMatrix {
 
     /// Confusingly returns true if the requested element is out of bounds
     pub fn check_in_bounds(&self, x: u32, y: u32) -> bool {
-        (self.get_offset(y, x)) > self.bits.len()
+        (self.get_offset(y, x)) >= self.bits.len()
     }
 
     /**

--- a/src/maxicode/detector.rs
+++ b/src/maxicode/detector.rs
@@ -281,7 +281,9 @@ impl Circle<'_> {
         // count left
         while {
             let point = get_point(self.center, (x, y), rotation);
-            !self.image.get(point.x as u32, point.y as u32) && x > 0
+            !self.image.check_in_bounds(point.x as u32, point.y as u32)
+                && !self.image.get(point.x as u32, point.y as u32)
+                && x > 0
         } {
             x -= 1;
             length += 1;
@@ -293,7 +295,8 @@ impl Circle<'_> {
         // count right
         while {
             let point = get_point(self.center, (x, y), rotation);
-            !self.image.get(point.x as u32, point.y as u32)
+            !self.image.check_in_bounds(point.x as u32, point.y as u32)
+                && !self.image.get(point.x as u32, point.y as u32)
         } {
             x += 1;
             length += 1;


### PR DESCRIPTION
In issue #28 I described that a certain image crashed the library. The problem was that the library got the value 
`point.y = 254.56.... `
when the image size was 254 which cause it to get an out-of-bound panic. I added the `check_for_bounds` function before getting the point in the image. 

Do we want to make the check inside of the `get` function  and return false for out-of-bound or maybe return a `Result`?

Fixes #28