### PR TITLE
Set `default-features = false` for image dependency

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,5 +20,7 @@ jobs:
       run: cargo check --workspace --release --verbose
     - name: Build
       run: cargo build --workspace --release --verbose
-    - name: Run tests
+    - name: Run tests (defaults)
       run: cargo test --workspace --release --verbose
+    - name: Run tests (minimal)
+      run: cargo test --workspace --release --verbose --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ urlencoding = "2.1.3"
 uriparse = "0.6.4"
 chrono = "0.4.31"
 chrono-tz = "0.8"
-image = {version = "0.24", optional = true}
+image = {version = "0.24", optional = true, default-features = false}
 imageproc = {version = "0.23", optional = true}
 unicode-segmentation = "1.10"
 codepage-437 = "0.1.0"
@@ -41,9 +41,28 @@ rand = "0.8.5"
 criterion = "0.5"
 
 [features]
-default = ["image", "client_support"]
+default = ["image", "client_support", "image-formats"]
 #/// Enable features required for image manipulation and reading.
 image = ["dep:image", "dep:imageproc"]
+image-formats = [
+    "image",
+    "image/gif",
+    "image/jpeg",
+    "image/ico",
+    "image/png",
+    "image/pnm",
+    "image/tga",
+    "image/tiff",
+    "image/webp",
+    "image/bmp",
+    "image/hdr",
+    "image/dxt",
+    "image/dds",
+    "image/farbfeld",
+    "image/jpeg_rayon",
+    "image/openexr",
+    "image/qoi"
+]
 
 #/// Allows the ability to force ISO/IED 18004 compliance.
 #/// Leave disabled unless specificially needed.

--- a/src/maxicode/detector.rs
+++ b/src/maxicode/detector.rs
@@ -1054,6 +1054,7 @@ mod detector_test {
         Binarizer, BufferedImageLuminanceSource,
     };
 
+    #[cfg(feature = "image-formats")]
     #[test]
     fn mode_1() {
         finder_test(
@@ -1062,6 +1063,7 @@ mod detector_test {
         )
     }
 
+    #[cfg(feature = "image-formats")]
     #[test]
     fn mode_2() {
         finder_test(
@@ -1070,6 +1072,7 @@ mod detector_test {
         )
     }
 
+    #[cfg(feature = "image-formats")]
     #[test]
     fn mode_2_rot90() {
         finder_test(
@@ -1078,6 +1081,7 @@ mod detector_test {
         )
     }
 
+    #[cfg(feature = "image-formats")]
     #[test]
     fn mode3() {
         finder_test(
@@ -1086,6 +1090,7 @@ mod detector_test {
         )
     }
 
+    #[cfg(feature = "image-formats")]
     #[test]
     fn mixed_sets() {
         finder_test(
@@ -1094,6 +1099,7 @@ mod detector_test {
         )
     }
 
+    #[cfg(feature = "image-formats")]
     #[test]
     fn mode4() {
         finder_test(
@@ -1102,6 +1108,7 @@ mod detector_test {
         )
     }
 
+    #[cfg(feature = "image-formats")]
     #[test]
     fn mode5() {
         finder_test(
@@ -1110,6 +1117,7 @@ mod detector_test {
         )
     }
 
+    #[cfg(feature = "image-formats")]
     #[test]
     fn mode6() {
         finder_test(

--- a/src/multi/multi_test_case.rs
+++ b/src/multi/multi_test_case.rs
@@ -27,6 +27,7 @@ use super::{GenericMultipleBarcodeReader, MultipleBarcodeReader};
  * Tests {@link MultipleBarcodeReader}.
  */
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testMulti() {
     // Very basic test for now
@@ -54,6 +55,7 @@ fn testMulti() {
     assert_eq!(&BarcodeFormat::QR_CODE, results[1].getBarcodeFormat());
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testMultiQR() {
     // Very basic test for now

--- a/src/multi/qrcode/qr_code_multi_reader.rs
+++ b/src/multi/qrcode/qr_code_multi_reader.rs
@@ -237,6 +237,7 @@ mod multi_qr_code_test_case {
      * Tests {@link QRCodeMultiReader}.
      */
 
+    #[cfg(feature = "image-formats")]
     #[test]
     fn testMultiQRCodes() {
         // Very basic test for now

--- a/src/oned/rss/expanded/expanded_pair.rs
+++ b/src/oned/rss/expanded/expanded_pair.rs
@@ -63,7 +63,7 @@ impl ExpandedPair {
         &self.finderPattern
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "image"))]
     pub(crate) fn getFinderPatternMut(&mut self) -> &mut Option<FinderPattern> {
         &mut self.finderPattern
     }

--- a/src/oned/rss/expanded/expanded_row.rs
+++ b/src/oned/rss/expanded/expanded_row.rs
@@ -35,7 +35,7 @@ impl ExpandedRow {
         &self.pairs
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "image"))]
     pub(crate) fn getPairsMut(&mut self) -> &mut [ExpandedPair] {
         &mut self.pairs
     }

--- a/src/oned/rss/expanded/rss_expanded_image_2_binary_test_case.rs
+++ b/src/oned/rss/expanded/rss_expanded_image_2_binary_test_case.rs
@@ -35,6 +35,7 @@ use crate::{
 
 use super::bit_array_builder;
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2binary1() {
     // (11)100224(17)110224(3102)000100
@@ -42,6 +43,7 @@ fn testDecodeRow2binary1() {
         " ...X...X .X....X. .XX...X. X..X...X ...XX.X. ..X.X... ..X.X..X ...X..X. X.X....X .X....X. .....X.. X...X...");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2binary2() {
     // (01)90012345678908(3103)001750
@@ -51,12 +53,14 @@ fn testDecodeRow2binary2() {
     );
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2binary3() {
     // (10)12A
     assertCorrectImage2binary("3.png", " .......X ..XX..X. X.X....X .......X ....");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2binary4() {
     // (01)98898765432106(3202)012345(15)991231
@@ -64,6 +68,7 @@ fn testDecodeRow2binary4() {
         "4.png", " ..XXXX.X XX.XXXX. .XXX.XX. XX..X... .XXXXX.. XX.X..X. ..XX..XX XX.X.XXX X..XX..X .X.XXXXX XXXX");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2binary5() {
     // (01)90614141000015(3202)000150
@@ -73,6 +78,7 @@ fn testDecodeRow2binary5() {
     );
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2binary10() {
     // (01)98898765432106(15)991231(3103)001750(10)12A(422)123(21)123456(423)0123456789012
@@ -80,6 +86,7 @@ fn testDecodeRow2binary10() {
         " .X.XX..X XX.XXXX. .XXX.XX. XX..X... .XXXXX.. XX.X..X. ..XX...X XX.X.... X.X.X.X. X.X..X.X .X....X. XX...X.. ...XX.X. .XXXXXX. .X..XX.. X.X.X... .X...... XXXX.... XX.XX... XXXXX.X. ...XXXXX .....X.X ...X.... X.XXX..X X.X.X... XX.XX..X .X..X..X .X.X.X.X X.XX...X .XX.XXX. XXX.X.XX ..X.");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2binary11() {
     // (01)98898765432106(15)991231(3103)001750(10)12A(422)123(21)123456
@@ -87,6 +94,7 @@ fn testDecodeRow2binary11() {
         " .X.XX..X XX.XXXX. .XXX.XX. XX..X... .XXXXX.. XX.X..X. ..XX...X XX.X.... X.X.X.X. X.X..X.X .X....X. XX...X.. ...XX.X. .XXXXXX. .X..XX.. X.X.X... .X...... XXXX.... XX.XX... XXXXX.X. ...XXXXX .....X.X ...X.... X.XXX..X X.X.X... ....");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2binary12() {
     // (01)98898765432106(3103)001750
@@ -96,6 +104,7 @@ fn testDecodeRow2binary12() {
     );
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2binary13() {
     // (01)90012345678908(3922)795
@@ -105,6 +114,7 @@ fn testDecodeRow2binary13() {
     );
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2binary14() {
     // (01)90012345678908(3932)0401234
@@ -112,6 +122,7 @@ fn testDecodeRow2binary14() {
         "14.png", " ..XX.X.. ........ .X..XXX. X.X.X... XX.XXXXX .XXXX.X. X.....X. X.....X. X.X.X.XX .X...... X...");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2binary15() {
     // (01)90012345678908(3102)001750(11)100312
@@ -119,6 +130,7 @@ fn testDecodeRow2binary15() {
         "15.png", " ..XXX... ........ .X..XXX. X.X.X... XX.XXXXX .XXXX.X. ..XX...X .X.....X .XX..... XXXX.X.. XX..");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2binary16() {
     // (01)90012345678908(3202)001750(11)100312
@@ -126,6 +138,7 @@ fn testDecodeRow2binary16() {
         "16.png", " ..XXX..X ........ .X..XXX. X.X.X... XX.XXXXX .XXXX.X. ..XX...X .X.....X .XX..... XXXX.X.. XX..");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2binary17() {
     // (01)90012345678908(3102)001750(13)100312
@@ -133,6 +146,7 @@ fn testDecodeRow2binary17() {
         "17.png", " ..XXX.X. ........ .X..XXX. X.X.X... XX.XXXXX .XXXX.X. ..XX...X .X.....X .XX..... XXXX.X.. XX..");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2binary18() {
     // (01)90012345678908(3202)001750(13)100312
@@ -140,6 +154,7 @@ fn testDecodeRow2binary18() {
         "18.png", " ..XXX.XX ........ .X..XXX. X.X.X... XX.XXXXX .XXXX.X. ..XX...X .X.....X .XX..... XXXX.X.. XX..");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2binary19() {
     // (01)90012345678908(3102)001750(15)100312
@@ -147,6 +162,7 @@ fn testDecodeRow2binary19() {
         "19.png", " ..XXXX.. ........ .X..XXX. X.X.X... XX.XXXXX .XXXX.X. ..XX...X .X.....X .XX..... XXXX.X.. XX..");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2binary20() {
     // (01)90012345678908(3202)001750(15)100312
@@ -154,6 +170,7 @@ fn testDecodeRow2binary20() {
         "20.png", " ..XXXX.X ........ .X..XXX. X.X.X... XX.XXXXX .XXXX.X. ..XX...X .X.....X .XX..... XXXX.X.. XX..");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2binary21() {
     // (01)90012345678908(3102)001750(17)100312
@@ -161,6 +178,7 @@ fn testDecodeRow2binary21() {
         "21.png", " ..XXXXX. ........ .X..XXX. X.X.X... XX.XXXXX .XXXX.X. ..XX...X .X.....X .XX..... XXXX.X.. XX..");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2binary22() {
     // (01)90012345678908(3202)001750(17)100312

--- a/src/oned/rss/expanded/rss_expanded_image_2_string_test_case.rs
+++ b/src/oned/rss/expanded/rss_expanded_image_2_string_test_case.rs
@@ -37,36 +37,43 @@ use crate::{
  * @author Eduardo Castillejo, University of Deusto (eduardo.castillejo@deusto.es)
  */
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2string1() {
     assertCorrectImage2string("1.png", "(11)100224(17)110224(3102)000100");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2string2() {
     assertCorrectImage2string("2.png", "(01)90012345678908(3103)001750");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2string3() {
     assertCorrectImage2string("3.png", "(10)12A");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2string4() {
     assertCorrectImage2string("4.png", "(01)98898765432106(3202)012345(15)991231");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2string5() {
     assertCorrectImage2string("5.png", "(01)90614141000015(3202)000150");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2string7() {
     assertCorrectImage2string("7.png", "(10)567(11)010101");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2string10() {
     let expected =
@@ -74,6 +81,7 @@ fn testDecodeRow2string10() {
     assertCorrectImage2string("10.png", expected);
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2string11() {
     assertCorrectImage2string(
@@ -82,96 +90,115 @@ fn testDecodeRow2string11() {
     );
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2string12() {
     assertCorrectImage2string("12.png", "(01)98898765432106(3103)001750");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2string13() {
     assertCorrectImage2string("13.png", "(01)90012345678908(3922)795");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2string14() {
     assertCorrectImage2string("14.png", "(01)90012345678908(3932)0401234");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2string15() {
     assertCorrectImage2string("15.png", "(01)90012345678908(3102)001750(11)100312");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2string16() {
     assertCorrectImage2string("16.png", "(01)90012345678908(3202)001750(11)100312");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2string17() {
     assertCorrectImage2string("17.png", "(01)90012345678908(3102)001750(13)100312");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2string18() {
     assertCorrectImage2string("18.png", "(01)90012345678908(3202)001750(13)100312");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2string19() {
     assertCorrectImage2string("19.png", "(01)90012345678908(3102)001750(15)100312");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2string20() {
     assertCorrectImage2string("20.png", "(01)90012345678908(3202)001750(15)100312");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2string21() {
     assertCorrectImage2string("21.png", "(01)90012345678908(3102)001750(17)100312");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2string22() {
     assertCorrectImage2string("22.png", "(01)90012345678908(3202)001750(17)100312");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2string25() {
     assertCorrectImage2string("25.png", "(10)123");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2string26() {
     assertCorrectImage2string("26.png", "(10)5678(11)010101");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2string27() {
     assertCorrectImage2string("27.png", "(10)1098-1234");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2string28() {
     assertCorrectImage2string("28.png", "(10)1098/1234");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2string29() {
     assertCorrectImage2string("29.png", "(10)1098.1234");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2string30() {
     assertCorrectImage2string("30.png", "(10)1098*1234");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2string31() {
     assertCorrectImage2string("31.png", "(10)1098,1234");
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeRow2string32() {
     assertCorrectImage2string(

--- a/src/oned/rss/expanded/rss_expanded_internal_test_case.rs
+++ b/src/oned/rss/expanded/rss_expanded_internal_test_case.rs
@@ -37,6 +37,7 @@ use super::RSSExpandedReader;
  * @author Eduardo Castillejo, University of Deusto (eduardo.castillejo@deusto.es)
  */
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testFindFinderPatterns() {
     let image = readImage("2.png");
@@ -83,6 +84,7 @@ fn testFindFinderPatterns() {
     // }
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testRetrieveNextPairPatterns() {
     let image = readImage("3.png");
@@ -111,6 +113,7 @@ fn testRetrieveNextPairPatterns() {
     assert_eq!(0, finderPattern.getValue());
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeCheckCharacter() {
     let image = readImage("3.png");
@@ -139,6 +142,7 @@ fn testDecodeCheckCharacter() {
     assert_eq!(98, dataCharacter.getValue());
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodeDataCharacter() {
     let image = readImage("3.png");

--- a/src/oned/rss/expanded/rss_expanded_stacked_internal_test_case.rs
+++ b/src/oned/rss/expanded/rss_expanded_stacked_internal_test_case.rs
@@ -32,6 +32,7 @@ use super::{test_case_util, RSSExpandedReader};
  * Tests {@link RSSExpandedReader} handling of stacked RSS barcodes.
  */
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testDecodingRowByRow() {
     let mut rssExpandedReader = RSSExpandedReader::new();
@@ -87,6 +88,7 @@ fn testDecodingRowByRow() {
     assert_eq!("(01)98898765432106(3202)012345(15)991231", result.getText());
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn testCompleteDecode() {
     let mut rssExpandedReader = RSSExpandedReader::new();

--- a/src/oned/rss/finder_pattern.rs
+++ b/src/oned/rss/finder_pattern.rs
@@ -48,7 +48,7 @@ impl FinderPattern {
         &self.startEnd
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "image"))]
     pub(crate) fn getStartEndMut(&mut self) -> &mut [usize] {
         &mut self.startEnd
     }

--- a/src/qrcode/QRCodeWriterTestCase.rs
+++ b/src/qrcode/QRCodeWriterTestCase.rs
@@ -159,6 +159,7 @@ fn compareToGoldenFile(
 // Golden images are generated with "qrcode_sample.cc". The images are checked with both eye balls
 // and cell phones. We expect pixel-perfect results, because the error correction level is known,
 // and the pixel dimensions matches exactly.
+#[cfg(feature = "image-formats")]
 #[test]
 fn testRegressionTest() {
     compareToGoldenFile(

--- a/tests/aztec_blackbox_tests.rs
+++ b/tests/aztec_blackbox_tests.rs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#![cfg(feature = "image")]
 
 use rxing::{aztec::AztecReader, BarcodeFormat};
 

--- a/tests/aztec_blackbox_tests.rs
+++ b/tests/aztec_blackbox_tests.rs
@@ -22,6 +22,7 @@ mod common;
 /**
  * @author David Olivier
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn aztec_black_box1_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -44,6 +45,7 @@ fn aztec_black_box1_test_case() {
  *
  * @author dswitkin@google.com (Daniel Switkin)
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn aztec_black_box2_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(

--- a/tests/codabar_blackbox_1_test_case.rs
+++ b/tests/codabar_blackbox_1_test_case.rs
@@ -22,6 +22,7 @@ mod common;
 /**
  * @author Sean Owen
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn codabar_black_box1_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(

--- a/tests/codabar_blackbox_1_test_case.rs
+++ b/tests/codabar_blackbox_1_test_case.rs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#![cfg(feature = "image")]
 
 use rxing::{oned::CodaBarReader, BarcodeFormat};
 

--- a/tests/code_128_blackbox.rs
+++ b/tests/code_128_blackbox.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "image")]
+
 use rxing::{BarcodeFormat, MultiFormatReader};
 
 mod common;

--- a/tests/code_128_blackbox.rs
+++ b/tests/code_128_blackbox.rs
@@ -7,6 +7,7 @@ mod common;
 /**
  * @author Sean Owen
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn code128_black_box1_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -25,6 +26,7 @@ fn code128_black_box1_test_case() {
 /**
  * @author dswitkin@google.com (Daniel Switkin)
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn code128_black_box2_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -43,6 +45,7 @@ fn code128_black_box2_test_case() {
 /**
  * @author Sean Owen
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn code128_black_box3_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(

--- a/tests/code_39_blackbox_reader.rs
+++ b/tests/code_39_blackbox_reader.rs
@@ -14,6 +14,7 @@ mod common;
 /**
  * @author Sean Owen
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn code39_black_box1_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -34,6 +35,7 @@ fn code39_black_box1_test_case() {
 /**
  * @author dswitkin@google.com (Daniel Switkin)
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn code39_black_box3_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -52,6 +54,7 @@ fn code39_black_box3_test_case() {
 /**
  * @author Sean Owen
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn code39_extended_black_box2_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(

--- a/tests/code_39_blackbox_reader.rs
+++ b/tests/code_39_blackbox_reader.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "image")]
+
 /**
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/code_93_blackbox_1_testcase.rs
+++ b/tests/code_93_blackbox_1_testcase.rs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#![cfg(feature = "image")]
 
 use rxing::{BarcodeFormat, MultiFormatReader};
 

--- a/tests/code_93_blackbox_1_testcase.rs
+++ b/tests/code_93_blackbox_1_testcase.rs
@@ -22,6 +22,7 @@ mod common;
 /**
  * @author Sean Owen
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn code93_black_box1_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(

--- a/tests/cpp_qr_code_blackbox_tests.rs
+++ b/tests/cpp_qr_code_blackbox_tests.rs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#![cfg(feature = "image")]
 
 use rxing::{qrcode::cpp_port::QrReader, BarcodeFormat, MultiUseMultiFormatReader};
 

--- a/tests/cpp_qr_code_blackbox_tests.rs
+++ b/tests/cpp_qr_code_blackbox_tests.rs
@@ -23,6 +23,7 @@ mod common;
  * @author Sean Owen
  */
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn qrcode_black_box1_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -65,6 +66,7 @@ fn qrcode_black_box1_test_case() {
  * @author dswitkin@google.com (Daniel Switkin)
  */
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn qrcode_black_box3_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -86,6 +88,7 @@ fn qrcode_black_box3_test_case() {
  * @author dswitkin@google.com (Daniel Switkin)
  */
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn qrcode_black_box4_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -110,6 +113,7 @@ fn qrcode_black_box4_test_case() {
  * @author dswitkin@google.com (Daniel Switkin)
  */
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn qrcode_black_box5_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -130,6 +134,7 @@ fn qrcode_black_box5_test_case() {
  * rotation, which was a weak spot.
  */
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn qrcode_black_box6_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -145,6 +150,7 @@ fn qrcode_black_box6_test_case() {
     tester.test_black_box();
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn mqr_black_box_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -170,6 +176,7 @@ fn mqr_black_box_test_case() {
  * be a function of the barcode.
  */
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn cpp_qrcode_black_box1_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -190,6 +197,7 @@ fn cpp_qrcode_black_box1_test_case() {
  * @author Sean Owen
  */
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn cpp_qrcode_black_box2_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -218,6 +226,7 @@ fn cpp_qrcode_black_box2_test_case() {
  * @author dswitkin@google.com (Daniel Switkin)
  */
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn cpp_qrcode_black_box3_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -240,6 +249,7 @@ fn cpp_qrcode_black_box3_test_case() {
  * @author dswitkin@google.com (Daniel Switkin)
  */
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn cpp_qrcode_black_box4_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -264,6 +274,7 @@ fn cpp_qrcode_black_box4_test_case() {
  * @author dswitkin@google.com (Daniel Switkin)
  */
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn cpp_qrcode_black_box5_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -284,6 +295,7 @@ fn cpp_qrcode_black_box5_test_case() {
  * rotation, which was a weak spot.
  */
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn cpp_qrcode_black_box6_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -299,6 +311,7 @@ fn cpp_qrcode_black_box6_test_case() {
     tester.test_black_box();
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn cpp_qrcode_black_box7_test_case() {
     let mut tester = common::MultiImageSpanAbstractBlackBoxTestCase::new(

--- a/tests/datamatrix_black_box_test_cases.rs
+++ b/tests/datamatrix_black_box_test_cases.rs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#![cfg(feature = "image")]
 
 use rxing::MultiFormatReader;
 

--- a/tests/datamatrix_black_box_test_cases.rs
+++ b/tests/datamatrix_black_box_test_cases.rs
@@ -22,6 +22,7 @@ mod common;
 /**
  * @author bbrown@google.com (Brian Brown)
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn data_matrix_black_box1_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -41,6 +42,7 @@ fn data_matrix_black_box1_test_case() {
 /**
  * @author dswitkin@google.com (Daniel Switkin)
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn data_matrix_black_box2_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -60,6 +62,7 @@ fn data_matrix_black_box2_test_case() {
 /**
  * @author gitlost
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn data_matrix_black_box3_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(

--- a/tests/ean_13_blackbox_tests.rs
+++ b/tests/ean_13_blackbox_tests.rs
@@ -22,6 +22,7 @@ mod common;
 /**
  * @author Sean Owen
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn ean13_black_box1_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -43,6 +44,7 @@ fn ean13_black_box1_test_case() {
  *
  * @author dswitkin@google.com (Daniel Switkin)
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn ean13_black_box2_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -62,6 +64,7 @@ fn ean13_black_box2_test_case() {
 /**
  * @author dswitkin@google.com (Daniel Switkin)
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn ean13_black_box3_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -82,6 +85,7 @@ fn ean13_black_box3_test_case() {
  * A very difficult set of images taken with extreme shadows and highlights.
  * @author dswitkin@google.com (Daniel Switkin)
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn ean13_black_box4_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -101,6 +105,7 @@ fn ean13_black_box4_test_case() {
  * A set of blurry images taken with a fixed-focus device.
  * @author dswitkin@google.com (Daniel Switkin)
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn ean13_black_box5_blurry_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(

--- a/tests/ean_13_blackbox_tests.rs
+++ b/tests/ean_13_blackbox_tests.rs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#![cfg(feature = "image")]
 
 use rxing::{BarcodeFormat, MultiFormatReader};
 

--- a/tests/ean_8_black_box_1_testcase.rs
+++ b/tests/ean_8_black_box_1_testcase.rs
@@ -22,6 +22,7 @@ mod common;
 /**
  * @author Sean Owen
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn ean8_black_box1_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(

--- a/tests/ean_8_black_box_1_testcase.rs
+++ b/tests/ean_8_black_box_1_testcase.rs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#![cfg(feature = "image")]
 
 use rxing::{BarcodeFormat, MultiFormatReader};
 

--- a/tests/github_issues.rs
+++ b/tests/github_issues.rs
@@ -1,7 +1,5 @@
 use std::io::Read;
 
-use rxing::DecodingHintDictionary;
-
 #[test]
 fn issue_27_part_2() {
     let mut data = Vec::new();
@@ -13,8 +11,11 @@ fn issue_27_part_2() {
     rxing::helpers::detect_multiple_in_luma(data, 720, 618).unwrap_or_default();
 }
 
+#[cfg(feature = "image")]
 #[test]
 fn issue_28() {
+    use rxing::DecodingHintDictionary;
+
     let mut hints: DecodingHintDictionary = DecodingHintDictionary::new();
     hints.insert(
         rxing::DecodeHintType::TRY_HARDER,

--- a/tests/inverted_data_matrix_black_box_testcase.rs
+++ b/tests/inverted_data_matrix_black_box_testcase.rs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#![cfg(feature = "image")]
 
 use rxing::{DecodeHintType, DecodeHintValue, MultiFormatReader};
 

--- a/tests/inverted_data_matrix_black_box_testcase.rs
+++ b/tests/inverted_data_matrix_black_box_testcase.rs
@@ -22,6 +22,7 @@ mod common;
 /**
  * Inverted barcodes
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn inverted_data_matrix_black_box_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(

--- a/tests/itf_blackbox.rs
+++ b/tests/itf_blackbox.rs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#![cfg(feature = "image")]
 
 use rxing::{BarcodeFormat, MultiFormatReader};
 

--- a/tests/itf_blackbox.rs
+++ b/tests/itf_blackbox.rs
@@ -22,6 +22,7 @@ mod common;
 /**
  * @author kevin.osullivan@sita.aero
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn itfblack_box1_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -40,6 +41,7 @@ fn itfblack_box1_test_case() {
 /**
  * @author dswitkin@google.com (Daniel Switkin)
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn itfblack_box2_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(

--- a/tests/maxicode_blackbox_tests.rs
+++ b/tests/maxicode_blackbox_tests.rs
@@ -22,6 +22,7 @@ mod common;
 /**
  * Tests {@link MaxiCodeReader} against a fixed set of test images.
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn maxicode1_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -43,6 +44,7 @@ fn maxicode1_test_case() {
  * @author Daniel Gredler
  * @see <a href="https://github.com/zxing/zxing/issues/1543">Defect 1543</a>
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn maxi_code_black_box1_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(

--- a/tests/maxicode_blackbox_tests.rs
+++ b/tests/maxicode_blackbox_tests.rs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#![cfg(feature = "image")]
 
 use rxing::{BarcodeFormat, DecodeHintType, MultiFormatReader};
 

--- a/tests/pdf_417_black_box_4_testcase.rs
+++ b/tests/pdf_417_black_box_4_testcase.rs
@@ -25,6 +25,7 @@ use rxing::pdf417::PDF417Reader;
  *
  * @author Guenther Grau
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn pdf417_black_box4_test_case() {
     let mut tester = common::MultiImageSpanAbstractBlackBoxTestCase::new(

--- a/tests/pdf_417_black_box_4_testcase.rs
+++ b/tests/pdf_417_black_box_4_testcase.rs
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#![cfg(feature = "image")]
+
 mod common;
 
 use rxing::pdf417::PDF417Reader;

--- a/tests/pdf_417_blackbox_tests.rs
+++ b/tests/pdf_417_blackbox_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "image")]
+
 use rxing::MultiFormatReader;
 
 mod common;

--- a/tests/pdf_417_blackbox_tests.rs
+++ b/tests/pdf_417_blackbox_tests.rs
@@ -9,6 +9,7 @@ mod common;
  *
  * @author SITA Lab (kevin.osullivan@sita.aero)
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn pdf417_black_box1_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -30,6 +31,7 @@ fn pdf417_black_box1_test_case() {
  *
  * @author dswitkin@google.com (Daniel Switkin)
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn pdf417_black_box2_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -46,6 +48,7 @@ fn pdf417_black_box2_test_case() {
 /**
  * Tests {@link PDF417Reader} against more sample images.
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn pdf417_black_box3_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(

--- a/tests/qr_code_blackbox_tests.rs
+++ b/tests/qr_code_blackbox_tests.rs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#![cfg(feature = "image")]
 
 use rxing::{qrcode::QRCodeReader, BarcodeFormat, MultiFormatReader};
 

--- a/tests/qr_code_blackbox_tests.rs
+++ b/tests/qr_code_blackbox_tests.rs
@@ -23,6 +23,7 @@ mod common;
  * @author Sean Owen
  */
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn qrcode_black_box1_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -43,6 +44,7 @@ fn qrcode_black_box1_test_case() {
  * @author Sean Owen
  */
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn qrcode_black_box2_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -63,6 +65,7 @@ fn qrcode_black_box2_test_case() {
  * @author dswitkin@google.com (Daniel Switkin)
  */
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn qrcode_black_box3_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -84,6 +87,7 @@ fn qrcode_black_box3_test_case() {
  * @author dswitkin@google.com (Daniel Switkin)
  */
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn qrcode_black_box4_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -108,6 +112,7 @@ fn qrcode_black_box4_test_case() {
  * @author dswitkin@google.com (Daniel Switkin)
  */
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn qrcode_black_box5_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -128,6 +133,7 @@ fn qrcode_black_box5_test_case() {
  * rotation, which was a weak spot.
  */
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn qrcode_black_box6_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(

--- a/tests/rss_14_blackbox.rs
+++ b/tests/rss_14_blackbox.rs
@@ -22,6 +22,7 @@ mod common;
 /**
  * @author Sean Owen
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn rss14_black_box1_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -40,6 +41,7 @@ fn rss14_black_box1_test_case() {
 /**
  * @author Sean Owen
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn rss14_black_box2_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(

--- a/tests/rss_14_blackbox.rs
+++ b/tests/rss_14_blackbox.rs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#![cfg(feature = "image")]
 
 use rxing::{BarcodeFormat, MultiFormatReader};
 

--- a/tests/rss_expanded_blackbox.rs
+++ b/tests/rss_expanded_blackbox.rs
@@ -23,6 +23,7 @@
  *
  *   http://www.piramidepse.com/
  */
+#![cfg(feature = "image")]
 
 use rxing::{BarcodeFormat, MultiFormatReader};
 

--- a/tests/rss_expanded_blackbox.rs
+++ b/tests/rss_expanded_blackbox.rs
@@ -32,6 +32,7 @@ mod common;
 /**
  * A test of {@link RSSExpandedReader} against a fixed test set of images.
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn rssexpanded_black_box1_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -50,6 +51,7 @@ fn rssexpanded_black_box1_test_case() {
 /**
  * A test of {@link RSSExpandedReader} against a fixed test set of images.
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn rssexpanded_black_box2_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -68,6 +70,7 @@ fn rssexpanded_black_box2_test_case() {
 /**
  * A test of {@link RSSExpandedReader} against a fixed test set of images.
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn rssexpanded_black_box3_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -87,6 +90,7 @@ fn rssexpanded_black_box3_test_case() {
  * A test of {@link RSSExpandedReader} against a fixed test set of images including
  * stacked RSS barcodes.
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn rssexpanded_stacked_black_box1_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -106,6 +110,7 @@ fn rssexpanded_stacked_black_box1_test_case() {
  * A test of {@link RSSExpandedReader} against a fixed test set of images including
  * stacked RSS barcodes.
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn rssexpanded_stacked_black_box2_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(

--- a/tests/telepen_blackbox_1_test_case.rs
+++ b/tests/telepen_blackbox_1_test_case.rs
@@ -22,6 +22,7 @@ mod common;
 /**
  * @author Chris Wood
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn telepen_alpha_test_case() {
     const NUMTESTS: u32 = 5;
@@ -38,6 +39,7 @@ fn telepen_alpha_test_case() {
     tester.test_black_box();
 }
 
+#[cfg(feature = "image-formats")]
 #[test]
 fn telepen_numeric_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(

--- a/tests/telepen_blackbox_1_test_case.rs
+++ b/tests/telepen_blackbox_1_test_case.rs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#![cfg(feature = "image")]
 
 use rxing::{oned::TelepenReader, BarcodeFormat};
 

--- a/tests/upc_a_blackbox_tests.rs
+++ b/tests/upc_a_blackbox_tests.rs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#![cfg(feature = "image")]
 
 use rxing::{BarcodeFormat, MultiFormatReader};
 

--- a/tests/upc_a_blackbox_tests.rs
+++ b/tests/upc_a_blackbox_tests.rs
@@ -22,6 +22,7 @@ mod common;
 /**
  * @author Sean Owen
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn upcablack_box1_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -41,6 +42,7 @@ fn upcablack_box1_test_case() {
 /**
  * @author dswitkin@google.com (Daniel Switkin)
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn upcablack_box2_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -60,6 +62,7 @@ fn upcablack_box2_test_case() {
 /**
  * @author dswitkin@google.com (Daniel Switkin)
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn upcablack_box3_reflective_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -79,6 +82,7 @@ fn upcablack_box3_reflective_test_case() {
 /**
  * @author dswitkin@google.com (Daniel Switkin)
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn upcablack_box4_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -98,6 +102,7 @@ fn upcablack_box4_test_case() {
 /**
  * @author dswitkin@google.com (Daniel Switkin)
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn upcablack_box5_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -118,6 +123,7 @@ fn upcablack_box5_test_case() {
  * A set of blurry images taken with a fixed-focus device.
  * @author dswitkin@google.com (Daniel Switkin)
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn upcablack_box6_blurry_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(

--- a/tests/upc_e_blackbox_tests.rs
+++ b/tests/upc_e_blackbox_tests.rs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#![cfg(feature = "image")]
 
 use rxing::{BarcodeFormat, MultiFormatReader};
 

--- a/tests/upc_e_blackbox_tests.rs
+++ b/tests/upc_e_blackbox_tests.rs
@@ -22,6 +22,7 @@ mod common;
 /**
  * @author Sean Owen
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn upceblack_box1_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -41,6 +42,7 @@ fn upceblack_box1_test_case() {
 /**
  * @author dswitkin@google.com (Daniel Switkin)
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn upceblack_box2_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(
@@ -60,6 +62,7 @@ fn upceblack_box2_test_case() {
 /**
  * @author dswitkin@google.com (Daniel Switkin)
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn upceblack_box3_reflective_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(

--- a/tests/upc_ean_extension_black_box_1_testcase.rs
+++ b/tests/upc_ean_extension_black_box_1_testcase.rs
@@ -22,6 +22,7 @@ mod common;
 /**
  * @author Sean Owen
  */
+#[cfg(feature = "image-formats")]
 #[test]
 fn upceanextension_black_box1_test_case() {
     let mut tester = common::AbstractBlackBoxTestCase::new(

--- a/tests/upc_ean_extension_black_box_1_testcase.rs
+++ b/tests/upc_ean_extension_black_box_1_testcase.rs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#![cfg(feature = "image")]
 
 use rxing::{BarcodeFormat, MultiFormatReader};
 


### PR DESCRIPTION
Once enabled, there's no way to disable a cargo feature, so as a library, rxing probably shouldn't enable all the formats supported by the image crate.

This PR conditionally disables tests that depend on the `image` or `image-formats` features, introduces the `image-formats` feature and enables it by default, and adds a test step to the GitHub Actions workflow to test the crate with default features disabled.