### PR TITLE
refactor: Make it thread-safe

### DIFF
--- a/src/common/cpp_essentials/decoder_result.rs
+++ b/src/common/cpp_essentials/decoder_result.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::{common::ECIStringBuilder, Exceptions};
 
@@ -19,7 +19,7 @@ where
     //Error _error;
     //std::shared_ptr<CustomData> _extra;
     error: Option<Exceptions>,
-    extra: Rc<T>,
+    extra: Arc<T>,
 }
 
 impl<T> Default for DecoderResult<T>
@@ -135,13 +135,13 @@ where
         self
     }
 
-    pub fn extra(&self) -> Rc<T> {
+    pub fn extra(&self) -> Arc<T> {
         self.extra.clone()
     }
-    pub fn setExtra(&mut self, extra: Rc<T>) {
+    pub fn setExtra(&mut self, extra: Arc<T>) {
         self.extra = extra
     }
-    pub fn withExtra(mut self, extra: Rc<T>) -> DecoderResult<T> {
+    pub fn withExtra(mut self, extra: Arc<T>) -> DecoderResult<T> {
         self.setExtra(extra);
         self
     }

--- a/src/common/decoder_rxing_result.rs
+++ b/src/common/decoder_rxing_result.rs
@@ -18,7 +18,7 @@
 
 // import java.util.List;
 
-use std::{any::Any, rc::Rc};
+use std::{any::Any, sync::Arc};
 
 /**
  * <p>Encapsulates the result of decoding a matrix of bits. This typically
@@ -35,7 +35,7 @@ pub struct DecoderRXingResult {
     ecLevel: String,
     errorsCorrected: usize,
     erasures: usize,
-    other: Option<Rc<dyn Any>>,
+    other: Option<Arc<dyn Any + Send + Sync>>,
     structuredAppendParity: i32,
     structuredAppendSequenceNumber: i32,
     symbologyModifier: u32,
@@ -203,11 +203,11 @@ impl DecoderRXingResult {
     /**
      * @return arbitrary additional metadata
      */
-    pub fn getOther(&self) -> Option<Rc<dyn Any>> {
+    pub fn getOther(&self) -> Option<Arc<dyn Any + Send + Sync>> {
         self.other.clone()
     }
 
-    pub fn setOther(&mut self, other: Option<Rc<dyn Any>>) {
+    pub fn setOther(&mut self, other: Option<Arc<dyn Any + Send + Sync>>) {
         self.other = other
     }
 

--- a/src/common/minimal_eci_input.rs
+++ b/src/common/minimal_eci_input.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use std::{fmt, rc::Rc};
+use std::{fmt, sync::Arc};
 
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -250,7 +250,7 @@ impl MinimalECIInput {
         Ok(self.bytes[index] == 1000)
     }
 
-    fn addEdge(edges: &mut [Vec<Option<Rc<InputEdge>>>], to: usize, edge: Rc<InputEdge>) {
+    fn addEdge(edges: &mut [Vec<Option<Arc<InputEdge>>>], to: usize, edge: Arc<InputEdge>) {
         if edges[to][edge.encoderIndex].is_none()
             || edges[to][edge.encoderIndex]
                 // .clone()
@@ -266,9 +266,9 @@ impl MinimalECIInput {
     fn addEdges(
         stringToEncode: &str,
         encoderSet: &ECIEncoderSet,
-        edges: &mut [Vec<Option<Rc<InputEdge>>>],
+        edges: &mut [Vec<Option<Arc<InputEdge>>>],
         from: usize,
-        previous: Option<Rc<InputEdge>>,
+        previous: Option<Arc<InputEdge>>,
         fnc1: Option<&str>,
     ) {
         // let ch = stringToEncode.chars().nth(from).unwrap() as i16;
@@ -298,7 +298,7 @@ impl MinimalECIInput {
                 Self::addEdge(
                     edges,
                     from + 1,
-                    Rc::new(InputEdge::new(ch, encoderSet, i, previous.clone(), fnc1)),
+                    Arc::new(InputEdge::new(ch, encoderSet, i, previous.clone(), fnc1)),
                 );
             }
         }
@@ -383,7 +383,7 @@ impl MinimalECIInput {
 struct InputEdge {
     c: String,
     encoderIndex: usize, //the encoding of this edge
-    previous: Option<Rc<InputEdge>>,
+    previous: Option<Arc<InputEdge>>,
     cachedTotalSize: usize,
 }
 impl InputEdge {
@@ -393,7 +393,7 @@ impl InputEdge {
         c: &str,
         encoderSet: &ECIEncoderSet,
         encoderIndex: usize,
-        previous: Option<Rc<InputEdge>>,
+        previous: Option<Arc<InputEdge>>,
         fnc1: Option<&str>,
     ) -> Self {
         let mut size = if c == Self::FNC1_UNICODE {

--- a/src/datamatrix/encoder/encoder_context.rs
+++ b/src/datamatrix/encoder/encoder_context.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::common::{CharacterSet, Result};
 use crate::{Dimension, Exceptions};
@@ -24,7 +24,7 @@ use super::{SymbolInfo, SymbolInfoLookup, SymbolShapeHint};
 const ISO_8859_1_ENCODER: CharacterSet = CharacterSet::ISO8859_1;
 
 pub struct EncoderContext<'a> {
-    symbol_lookup: Rc<SymbolInfoLookup<'a>>,
+    symbol_lookup: Arc<SymbolInfoLookup<'a>>,
     msg: String,
     shape: SymbolShapeHint,
     minSize: Option<Dimension>,
@@ -39,7 +39,7 @@ pub struct EncoderContext<'a> {
 impl<'a> EncoderContext<'_> {
     pub fn with_symbol_info_lookup(
         msg: &str,
-        symbol_lookup: Rc<SymbolInfoLookup<'a>>,
+        symbol_lookup: Arc<SymbolInfoLookup<'a>>,
     ) -> Result<EncoderContext<'a>> {
         let mut new_self = EncoderContext::new(msg)?;
         new_self.symbol_lookup = symbol_lookup.clone();
@@ -67,7 +67,7 @@ impl<'a> EncoderContext<'_> {
             ));
         };
         Ok(Self {
-            symbol_lookup: Rc::new(SymbolInfoLookup::new()),
+            symbol_lookup: Arc::new(SymbolInfoLookup::new()),
             msg: sb,
             shape: SymbolShapeHint::FORCE_NONE,
             codewords: String::with_capacity(msg.chars().count()),

--- a/src/datamatrix/encoder/high_level_encode_test_case.rs
+++ b/src/datamatrix/encoder/high_level_encode_test_case.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use std::rc::Rc;
+use std::sync::Arc;
 
 use once_cell::sync::Lazy;
 
@@ -121,7 +121,7 @@ fn testC40EncodationSpecialCases1() {
     let substitute_symbols = SymbolInfoLookup::new();
     let substitute_symbols = useTestSymbols(substitute_symbols);
 
-    let sil = Rc::new(substitute_symbols);
+    let sil = Arc::new(substitute_symbols);
 
     let visualized = encodeHighLevelCompareSIL("AIMAIMAIMAIMAIMAIM", false, Some(sil.clone()));
     assert_eq!("230 91 11 91 11 91 11 91 11 91 11 91 11", visualized);
@@ -136,7 +136,7 @@ fn testC40EncodationSpecialCases1() {
     //case "c": Unlatch and write last character in ASCII
 
     let substitute_symbols = resetSymbols(substitute_symbols);
-    let sil = Rc::new(substitute_symbols);
+    let sil = Arc::new(substitute_symbols);
 
     let visualized = encodeHighLevelSIL("AIMAIMAIMAIMAIMAI", sil.clone());
     assert_eq!(
@@ -565,14 +565,14 @@ fn encodeHighLevel(msg: &str) -> String {
     encodeHighLevelCompare(msg, true)
 }
 
-fn encodeHighLevelSIL(msg: &str, sil: Rc<SymbolInfoLookup>) -> String {
+fn encodeHighLevelSIL(msg: &str, sil: Arc<SymbolInfoLookup>) -> String {
     encodeHighLevelCompareSIL(msg, true, Some(sil))
 }
 
 fn encodeHighLevelCompareSIL(
     msg: &str,
     compareSizeToMinimalEncoder: bool,
-    sil: Option<Rc<SymbolInfoLookup>>,
+    sil: Option<Arc<SymbolInfoLookup>>,
 ) -> String {
     let encoded = high_level_encoder::encodeHighLevelSIL(msg, sil).expect("encodes");
     let encoded2 = minimal_encoder::encodeHighLevel(msg).expect("encodes");

--- a/src/datamatrix/encoder/high_level_encoder.rs
+++ b/src/datamatrix/encoder/high_level_encoder.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::common::{CharacterSet, Result};
 use crate::{Dimension, Exceptions};
@@ -146,7 +146,7 @@ pub fn encodeHighLevel(msg: &str) -> Result<String> {
  */
 pub fn encodeHighLevelSIL(
     msg: &str,
-    symbol_lookup: Option<Rc<SymbolInfoLookup>>,
+    symbol_lookup: Option<Arc<SymbolInfoLookup>>,
 ) -> Result<String> {
     encodeHighLevelWithDimensionForceC40WithSymbolInfoLookup(
         msg,
@@ -184,17 +184,17 @@ pub fn encodeHighLevelWithDimensionForceC40WithSymbolInfoLookup(
     minSize: Option<Dimension>,
     maxSize: Option<Dimension>,
     forceC40: bool,
-    symbol_lookup: Option<Rc<SymbolInfoLookup>>,
+    symbol_lookup: Option<Arc<SymbolInfoLookup>>,
 ) -> Result<String> {
     //the codewords 0..255 are encoded as Unicode characters
-    let c40Encoder = Rc::new(C40Encoder::new());
-    let encoders: [Rc<dyn Encoder>; 6] = [
-        Rc::new(ASCIIEncoder::new()),
+    let c40Encoder = Arc::new(C40Encoder::new());
+    let encoders: [Arc<dyn Encoder>; 6] = [
+        Arc::new(ASCIIEncoder::new()),
         c40Encoder.clone(),
-        Rc::new(TextEncoder::new()),
-        Rc::new(X12Encoder::new()),
-        Rc::new(EdifactEncoder::new()),
-        Rc::new(Base256Encoder::new()),
+        Arc::new(TextEncoder::new()),
+        Arc::new(X12Encoder::new()),
+        Arc::new(EdifactEncoder::new()),
+        Arc::new(Base256Encoder::new()),
     ];
 
     let mut context = if let Some(symbol_table) = symbol_lookup {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ pub mod qrcode;
 #[cfg(feature = "client_support")]
 pub mod client;
 
-use std::{collections::HashMap, rc::Rc};
+use std::{collections::HashMap, sync::Arc};
 
 pub use exceptions::Exceptions;
 
@@ -39,7 +39,7 @@ pub use encode_hints::*;
 
 /// Callback which is invoked when a possible result point (significant
 /// point in the barcode image such as a corner) is found.
-pub type PointCallback = Rc<dyn Fn(Point)>;
+pub type PointCallback = Arc<dyn Fn(Point)>;
 
 /** Temporary type to ease refactoring and keep backwards-compatibility */
 pub type RXingResultPointCallback = PointCallback;

--- a/src/pdf417/decoder/bounding_box.rs
+++ b/src/pdf417/decoder/bounding_box.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::{
     common::{BitMatrix, Result},
@@ -26,7 +26,7 @@ use crate::{
  */
 #[derive(Clone)]
 pub struct BoundingBox {
-    image: Rc<BitMatrix>,
+    image: Arc<BitMatrix>,
     topLeft: Point,
     bottomLeft: Point,
     topRight: Point,
@@ -38,7 +38,7 @@ pub struct BoundingBox {
 }
 impl BoundingBox {
     pub fn new(
-        image: Rc<BitMatrix>,
+        image: Arc<BitMatrix>,
         topLeft: Option<Point>,
         bottomLeft: Option<Point>,
         topRight: Option<Point>,
@@ -85,7 +85,7 @@ impl BoundingBox {
         })
     }
 
-    pub fn from_other(boundingBox: Rc<BoundingBox>) -> BoundingBox {
+    pub fn from_other(boundingBox: Arc<BoundingBox>) -> BoundingBox {
         BoundingBox {
             image: boundingBox.image.clone(),
             topLeft: boundingBox.topLeft,

--- a/src/pdf417/decoder/decoded_bit_stream_parser.rs
+++ b/src/pdf417/decoder/decoded_bit_stream_parser.rs
@@ -16,7 +16,7 @@
  */
 
 use num::{self, bigint::ToBigUint, BigUint};
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::{
     common::{DecoderRXingResult, ECIStringBuilder, Eci, Result},
@@ -171,7 +171,7 @@ pub fn decode(codewords: &[u32], ecLevel: &str) -> Result<DecoderRXingResult> {
         Vec::new(),
         ecLevel.to_owned(),
     );
-    decoderRXingResult.setOther(Some(Rc::new(resultMetadata)));
+    decoderRXingResult.setOther(Some(Arc::new(resultMetadata)));
 
     Ok(decoderRXingResult)
 }

--- a/src/pdf417/decoder/detection_result.rs
+++ b/src/pdf417/decoder/detection_result.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use std::{fmt::Display, rc::Rc};
+use std::{fmt::Display, sync::Arc};
 
 use crate::pdf417::pdf_417_common;
 
@@ -31,14 +31,14 @@ const ADJUST_ROW_NUMBER_SKIP: u32 = 2;
 pub struct DetectionRXingResult {
     barcodeMetadata: BarcodeMetadata,
     detectionRXingResultColumns: Vec<Option<Box<dyn DetectionRXingResultColumnTrait>>>,
-    boundingBox: Rc<BoundingBox>,
+    boundingBox: Arc<BoundingBox>,
     barcodeColumnCount: usize,
 }
 
 impl DetectionRXingResult {
     pub fn new(
         barcodeMetadata: BarcodeMetadata,
-        boundingBox: Rc<BoundingBox>,
+        boundingBox: Arc<BoundingBox>,
     ) -> DetectionRXingResult {
         let mut columns = Vec::with_capacity(barcodeMetadata.getColumnCount() as usize + 2);
         for _i in 0..(barcodeMetadata.getColumnCount() as usize + 2) {
@@ -601,11 +601,11 @@ impl DetectionRXingResult {
         self.barcodeMetadata.getErrorCorrectionLevel()
     }
 
-    pub fn setBoundingBox(&mut self, boundingBox: Rc<BoundingBox>) {
+    pub fn setBoundingBox(&mut self, boundingBox: Arc<BoundingBox>) {
         self.boundingBox = boundingBox;
     }
 
-    pub fn getBoundingBox(&self) -> Rc<BoundingBox> {
+    pub fn getBoundingBox(&self) -> Arc<BoundingBox> {
         self.boundingBox.clone()
     }
 

--- a/src/pdf417/decoder/detection_result_column.rs
+++ b/src/pdf417/decoder/detection_result_column.rs
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-use std::{fmt::Display, rc::Rc};
+use std::{fmt::Display, sync::Arc};
 
 use super::{BoundingBox, Codeword, DetectionRXingResultRowIndicatorColumn};
 
 const MAX_NEARBY_DISTANCE: u32 = 5;
 
 pub trait DetectionRXingResultColumnTrait {
-    fn new_column(boundingBox: Rc<BoundingBox>) -> DetectionRXingResultColumn
+    fn new_column(boundingBox: Arc<BoundingBox>) -> DetectionRXingResultColumn
     where
         Self: Sized;
-    fn new_with_is_left(boundingBox: Rc<BoundingBox>, isLeft: bool) -> DetectionRXingResultColumn
+    fn new_with_is_left(boundingBox: Arc<BoundingBox>, isLeft: bool) -> DetectionRXingResultColumn
     where
         Self: Sized;
     fn getCodewordNearby(&self, imageRow: u32) -> &Option<Codeword>;
@@ -48,7 +48,7 @@ pub struct DetectionRXingResultColumn {
 }
 
 impl DetectionRXingResultColumnTrait for DetectionRXingResultColumn {
-    fn new_column(boundingBox: Rc<BoundingBox>) -> DetectionRXingResultColumn {
+    fn new_column(boundingBox: Arc<BoundingBox>) -> DetectionRXingResultColumn {
         DetectionRXingResultColumn {
             boundingBox: BoundingBox::from_other(boundingBox.clone()),
             codewords: vec![None; (boundingBox.getMaxY() - boundingBox.getMinY() + 1) as usize],
@@ -56,7 +56,7 @@ impl DetectionRXingResultColumnTrait for DetectionRXingResultColumn {
         }
     }
 
-    fn new_with_is_left(boundingBox: Rc<BoundingBox>, isLeft: bool) -> DetectionRXingResultColumn {
+    fn new_with_is_left(boundingBox: Arc<BoundingBox>, isLeft: bool) -> DetectionRXingResultColumn {
         DetectionRXingResultColumn {
             boundingBox: BoundingBox::from_other(boundingBox.clone()),
             codewords: vec![None; (boundingBox.getMaxY() - boundingBox.getMinY() + 1) as usize],

--- a/src/pdf417/decoder/ec/modulus_gf.rs
+++ b/src/pdf417/decoder/ec/modulus_gf.rs
@@ -29,8 +29,8 @@ use crate::Exceptions;
 pub struct ModulusGF {
     expTable: Vec<u32>,
     logTable: Vec<u32>,
-    // zero: Option<Rc<ModulusPoly<'a>>>,
-    // one: Option<Rc<ModulusPoly<'a>>>,
+    // zero: Option<Arc<ModulusPoly<'a>>>,
+    // one: Option<Arc<ModulusPoly<'a>>>,
     modulus: u32,
     generator: u32,
 }

--- a/src/pdf417/decoder/ec/modulus_poly.rs
+++ b/src/pdf417/decoder/ec/modulus_poly.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::common::Result;
 use crate::Exceptions;
@@ -28,8 +28,8 @@ use super::ModulusGF;
 pub struct ModulusPoly {
     field: &'static ModulusGF,
     coefficients: Vec<u32>,
-    // zero: Option<Rc<ModulusPoly>>,
-    // one: Option<Rc<ModulusPoly>>,
+    // zero: Option<Arc<ModulusPoly>>,
+    // one: Option<Arc<ModulusPoly>>,
 }
 impl ModulusPoly {
     pub fn new(field: &'static ModulusGF, coefficients: Vec<u32>) -> Result<ModulusPoly> {
@@ -122,7 +122,7 @@ impl ModulusPoly {
         result
     }
 
-    pub fn add(&self, other: Rc<ModulusPoly>) -> Result<Rc<ModulusPoly>> {
+    pub fn add(&self, other: Arc<ModulusPoly>) -> Result<Arc<ModulusPoly>> {
         if self.field != other.field {
             return Err(Exceptions::illegal_argument_with(
                 "ModulusPolys do not have same ModulusGF field",
@@ -132,7 +132,7 @@ impl ModulusPoly {
             return Ok(other);
         }
         if other.isZero() {
-            return Ok(Rc::new(self.clone()));
+            return Ok(Arc::new(self.clone()));
         }
 
         let mut smallerCoefficients = &self.coefficients;
@@ -153,22 +153,22 @@ impl ModulusPoly {
                 .add(smallerCoefficients[i - lengthDiff], largerCoefficients[i]);
         }
 
-        Ok(Rc::new(ModulusPoly::new(self.field, sumDiff)?))
+        Ok(Arc::new(ModulusPoly::new(self.field, sumDiff)?))
     }
 
-    pub fn subtract(&self, other: Rc<ModulusPoly>) -> Result<Rc<ModulusPoly>> {
+    pub fn subtract(&self, other: Arc<ModulusPoly>) -> Result<Arc<ModulusPoly>> {
         if self.field != other.field {
             return Err(Exceptions::illegal_argument_with(
                 "ModulusPolys do not have same ModulusGF field",
             ));
         }
         if other.isZero() {
-            return Ok(Rc::new(self.clone()));
+            return Ok(Arc::new(self.clone()));
         };
         self.add(other.negative())
     }
 
-    pub fn multiply(&self, other: Rc<ModulusPoly>) -> Result<Rc<ModulusPoly>> {
+    pub fn multiply(&self, other: Arc<ModulusPoly>) -> Result<Arc<ModulusPoly>> {
         if !(self.field == other.field) {
             return Err(Exceptions::illegal_argument_with(
                 "ModulusPolys do not have same ModulusGF field",
@@ -194,28 +194,28 @@ impl ModulusPoly {
             }
         }
 
-        Ok(Rc::new(ModulusPoly::new(self.field, product)?))
+        Ok(Arc::new(ModulusPoly::new(self.field, product)?))
     }
 
-    pub fn negative(&self) -> Rc<ModulusPoly> {
+    pub fn negative(&self) -> Arc<ModulusPoly> {
         let size = self.coefficients.len();
         let mut negativeCoefficients = vec![0u32; size];
         for (i, neg_coef) in negativeCoefficients.iter_mut().enumerate().take(size) {
             // for (int i = 0; i < size; i++) {
             *neg_coef = self.field.subtract(0, self.coefficients[i]);
         }
-        Rc::new(
+        Arc::new(
             ModulusPoly::new(self.field, negativeCoefficients)
                 .expect("should always generate with known goods"),
         )
     }
 
-    pub fn multiplyByScaler(&self, scalar: u32) -> Rc<ModulusPoly> {
+    pub fn multiplyByScaler(&self, scalar: u32) -> Arc<ModulusPoly> {
         if scalar == 0 {
             return Self::getZero(self.field);
         }
         if scalar == 1 {
-            return Rc::new(self.clone());
+            return Arc::new(self.clone());
         }
         let size = self.coefficients.len();
         let mut product = vec![0u32; size];
@@ -224,12 +224,12 @@ impl ModulusPoly {
             *prod = self.field.multiply(self.coefficients[i], scalar);
         }
 
-        Rc::new(
+        Arc::new(
             ModulusPoly::new(self.field, product).expect("should always generate with known goods"),
         )
     }
 
-    pub fn multiplyByMonomial(&self, degree: usize, coefficient: u32) -> Rc<ModulusPoly> {
+    pub fn multiplyByMonomial(&self, degree: usize, coefficient: u32) -> Arc<ModulusPoly> {
         if coefficient == 0 {
             return Self::getZero(self.field);
         }
@@ -240,24 +240,24 @@ impl ModulusPoly {
             *prod = self.field.multiply(self.coefficients[i], coefficient);
         }
 
-        Rc::new(
+        Arc::new(
             ModulusPoly::new(self.field, product).expect("should always generate with known goods"),
         )
     }
 
-    pub fn getZero(field: &'static ModulusGF) -> Rc<ModulusPoly> {
-        Rc::new(ModulusPoly::new(field, vec![0]).expect("should always generate with known goods"))
+    pub fn getZero(field: &'static ModulusGF) -> Arc<ModulusPoly> {
+        Arc::new(ModulusPoly::new(field, vec![0]).expect("should always generate with known goods"))
     }
 
-    pub fn getOne(field: &'static ModulusGF) -> Rc<ModulusPoly> {
-        Rc::new(ModulusPoly::new(field, vec![1]).expect("should always generate with known goods"))
+    pub fn getOne(field: &'static ModulusGF) -> Arc<ModulusPoly> {
+        Arc::new(ModulusPoly::new(field, vec![1]).expect("should always generate with known goods"))
     }
 
     pub fn buildMonomial(
         field: &'static ModulusGF,
         degree: usize,
         coefficient: u32,
-    ) -> Rc<ModulusPoly> {
+    ) -> Arc<ModulusPoly> {
         // if degree < 0 {
         //   throw new IllegalArgumentException();
         // }
@@ -266,7 +266,7 @@ impl ModulusPoly {
         }
         let mut coefficients = vec![0_u32; degree + 1];
         coefficients[0] = coefficient;
-        Rc::new(
+        Arc::new(
             ModulusPoly::new(field, coefficients).expect("should always generate with known goods"),
         )
     }

--- a/src/pdf417/decoder/pdf_417_scanning_decoder.rs
+++ b/src/pdf417/decoder/pdf_417_scanning_decoder.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::{
     common::{BitMatrix, DecoderRXingResult, Result},
@@ -53,8 +53,8 @@ pub fn decode(
 ) -> Result<DecoderRXingResult> {
     let mut minCodewordWidth = minCodewordWidth;
     let mut maxCodewordWidth = maxCodewordWidth;
-    let mut boundingBox = Rc::new(BoundingBox::new(
-        Rc::new(image.clone()),
+    let mut boundingBox = Arc::new(BoundingBox::new(
+        Arc::new(image.clone()),
         image_top_left,
         imageBottomLeft,
         image_top_right,
@@ -188,7 +188,7 @@ fn merge<'a, T: DetectionRXingResultRowIndicatorColumn>(
     if barcodeMetadata.is_none() {
         return Ok(None);
     }
-    let boundingBox = Rc::new(BoundingBox::merge(
+    let boundingBox = Arc::new(BoundingBox::merge(
         adjustBoundingBox(leftRowIndicatorColumn)?,
         adjustBoundingBox(rightRowIndicatorColumn)?,
     )?);
@@ -357,7 +357,7 @@ fn getBarcodeMetadata<T: DetectionRXingResultRowIndicatorColumn>(
 
 fn getRowIndicatorColumn<'a>(
     image: &BitMatrix,
-    boundingBox: Rc<BoundingBox>,
+    boundingBox: Arc<BoundingBox>,
     startPoint: Point,
     leftToRight: bool,
     minCodewordWidth: u32,

--- a/src/qrcode/decoder/qrcode_decoder.rs
+++ b/src/qrcode/decoder/qrcode_decoder.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use std::{collections::HashMap, rc::Rc};
+use std::{collections::HashMap, sync::Arc};
 
 /**
  * <p>The main class which implements QR Code decoding -- as opposed to locating and extracting
@@ -117,7 +117,7 @@ pub fn decode_bitmatrix_with_hints(
         let mut result = decode_bitmatrix_parser_with_hints(&mut parser, hints)?;
 
         // Success! Notify the caller that the code was mirrored.
-        result.setOther(Some(Rc::new(QRCodeDecoderMetaData::new(true))));
+        result.setOther(Some(Arc::new(QRCodeDecoderMetaData::new(true))));
 
         Ok(result)
     };

--- a/src/qrcode/encoder/minimal_encoder.rs
+++ b/src/qrcode/encoder/minimal_encoder.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use std::{fmt, rc::Rc};
+use std::{fmt, sync::Arc};
 
 use crate::{
     common::{BitArray, BitFieldBaseType, CharacterSet, ECIEncoderSet, Result},
@@ -253,9 +253,9 @@ impl MinimalEncoder {
 
     pub fn addEdge(
         &self,
-        edges: &mut [Vec<Vec<Option<Rc<Edge>>>>],
+        edges: &mut [Vec<Vec<Option<Arc<Edge>>>>],
         position: usize,
-        edge: Option<Rc<Edge>>,
+        edge: Option<Arc<Edge>>,
     ) -> Result<()> {
         let vertexIndex =
             position + edge.as_ref().ok_or(Exceptions::FORMAT)?.characterLength as usize;
@@ -280,9 +280,9 @@ impl MinimalEncoder {
     pub fn addEdges(
         &self,
         version: VersionRef,
-        edges: &mut [Vec<Vec<Option<Rc<Edge>>>>],
+        edges: &mut [Vec<Vec<Option<Arc<Edge>>>>],
         from: usize,
-        previous: Option<Rc<Edge>>,
+        previous: Option<Arc<Edge>>,
     ) -> Result<()> {
         let mut start = 0;
         let mut end = self.encoders.len();
@@ -314,7 +314,7 @@ impl MinimalEncoder {
                 self.addEdge(
                     edges,
                     from,
-                    Some(Rc::new(
+                    Some(Arc::new(
                         Edge::new(
                             Mode::BYTE,
                             from,
@@ -338,7 +338,7 @@ impl MinimalEncoder {
             self.addEdge(
                 edges,
                 from,
-                Some(Rc::new(
+                Some(Arc::new(
                     Edge::new(
                         Mode::KANJI,
                         from,
@@ -364,7 +364,7 @@ impl MinimalEncoder {
             self.addEdge(
                 edges,
                 from,
-                Some(Rc::new(
+                Some(Arc::new(
                     Edge::new(
                         Mode::ALPHANUMERIC,
                         from,
@@ -400,7 +400,7 @@ impl MinimalEncoder {
             self.addEdge(
                 edges,
                 from,
-                Some(Rc::new(
+                Some(Arc::new(
                     Edge::new(
                         Mode::NUMERIC,
                         from,
@@ -616,7 +616,7 @@ pub struct Edge {
     fromPosition: usize,
     charsetEncoderIndex: usize,
     characterLength: u32,
-    previous: Option<Rc<Edge>>,
+    previous: Option<Arc<Edge>>,
     cachedTotalSize: u32,
     _encoders: ECIEncoderSet,
     _stringToEncode: Vec<String>,
@@ -628,7 +628,7 @@ impl Edge {
         fromPosition: usize,
         charsetEncoderIndex: usize,
         characterLength: u32,
-        previous: Option<Rc<Edge>>,
+        previous: Option<Arc<Edge>>,
         version: VersionRef,
         encoders: ECIEncoderSet,
         stringToEncode: Vec<String>,
@@ -701,7 +701,7 @@ pub struct RXingResultList {
 impl RXingResultList {
     pub fn new(
         version: VersionRef,
-        solution: Rc<Edge>,
+        solution: Arc<Edge>,
         isGS1: bool,
         ecLevel: &ErrorCorrectionLevel,
         encoders: ECIEncoderSet,

--- a/src/rxing_result_metadata.rs
+++ b/src/rxing_result_metadata.rs
@@ -16,7 +16,7 @@
 
 //package com.google.zxing;
 
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::pdf417::PDF417RXingResultMetadata;
 
@@ -216,7 +216,7 @@ pub enum RXingResultMetadataValue {
     /**
      * PDF417-specific metadata
      */
-    Pdf417ExtraMetadata(Rc<PDF417RXingResultMetadata>),
+    Pdf417ExtraMetadata(Arc<PDF417RXingResultMetadata>),
 
     /**
      * If the code format supports structured append and the current scanned code is part of one then the

--- a/tests/common/abstract_black_box_test_case.rs
+++ b/tests/common/abstract_black_box_test_case.rs
@@ -21,7 +21,7 @@ use std::{
     fs::{read_dir, read_to_string, File},
     io::Read,
     path::{Path, PathBuf},
-    rc::Rc,
+    sync::Arc,
 };
 
 use encoding::Encoding;
@@ -221,7 +221,7 @@ impl<T: Reader> AbstractBlackBoxTestCase<T> {
                         RXingResultMetadataValue::UpcEanExtension(v)
                     }
                     RXingResultMetadataType::PDF417_EXTRA_METADATA => {
-                        RXingResultMetadataValue::Pdf417ExtraMetadata(Rc::new(
+                        RXingResultMetadataValue::Pdf417ExtraMetadata(Arc::new(
                             PDF417RXingResultMetadata::default(),
                         ))
                     }

--- a/tests/common/multiimage_span.rs
+++ b/tests/common/multiimage_span.rs
@@ -20,7 +20,7 @@ use std::{
     fs::{read_dir, read_to_string, File},
     io::Read,
     path::{Path, PathBuf},
-    rc::Rc,
+    sync::Arc,
 };
 
 use rxing::{
@@ -377,7 +377,7 @@ impl<T: MultipleBarcodeReader + Reader> MultiImageSpanAbstractBlackBoxTestCase<T
                         RXingResultMetadataValue::UpcEanExtension(v)
                     }
                     RXingResultMetadataType::PDF417_EXTRA_METADATA => {
-                        RXingResultMetadataValue::Pdf417ExtraMetadata(Rc::new(
+                        RXingResultMetadataValue::Pdf417ExtraMetadata(Arc::new(
                             PDF417RXingResultMetadata::default(),
                         ))
                     }
@@ -771,7 +771,7 @@ impl<T: MultipleBarcodeReader + Reader> MultiImageSpanAbstractBlackBoxTestCase<T
         // return op.filter(original, new BufferedImage(width, height, original.getType()));
     }
 
-    fn get_meta(result: &RXingResult) -> Option<Rc<PDF417RXingResultMetadata>> {
+    fn get_meta(result: &RXingResult) -> Option<Arc<PDF417RXingResultMetadata>> {
         if let Some(RXingResultMetadataValue::Pdf417ExtraMetadata(mtd)) = result
             .getRXingResultMetadata()
             .get(&RXingResultMetadataType::PDF417_EXTRA_METADATA)


### PR DESCRIPTION
The current implementation of rxing uses Rc for reference counting, which is not thread-safe. This limitation restricts the library’s use in multi-threaded applications where safe concurrent access to shared resources is required.

Passed all test cases successfully.