### PR TITLE
fix: wasm_support feature has no effect

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ once_cell = "1.19"
 encoding = "0.2"
 urlencoding = "2.1.3"
 uriparse = "0.6.4"
-chrono = "0.4.38"
+chrono = { version = "0.4.38", default-features = false, features = ["clock", "std", "oldtime"] }
 chrono-tz = "0.9"
 image = {version = "0.25.2", optional = true, default-features = false}
 imageproc = {version = "0.25", optional = true}


### PR DESCRIPTION
chrono has its `wasmbind` feature [activated by default](https://docs.rs/crate/chrono/0.4.38/features#wasmbind). It voids the `wasm_support` feature which is expected to control `chrono/wasmbind`. 

The PR fixes this issue by disabling the default features of chrono.