### PR TITLE
Add image size default for encoding.

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -107,9 +107,9 @@ enum Commands {
     ))]
     Encode {
         barcode_type: BarcodeFormat,
-        #[arg(long)]
+        #[arg(long, default_value_t = 500)]
         width: u32,
-        #[arg(long)]
+        #[arg(long, default_value_t = 500)]
         height: u32,
 
         /// String input for the encoder.


### PR DESCRIPTION
Adds default size to image encoding. Seems worthwhile since it simplifies the command line a lot for those that, like me, don't have any specific requirements on size. 

Side note, I had to branch off an earlier commit since builds are failing on main. The patch should still apply to main though I expect. 
 