### PR TITLE
add cli option `--detailed-result-json` to print results in JSON

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["barcode", "barcode_1d", "barcode_2d", "barcode_reader", "barcode_wr
 [dependencies]
 clap = { version = "4.5.23", features = ["derive"] }
 rxing = {path = "../../", version = "~0.7.0", features = ["image", "svg_read", "svg_write"] }
+serde_json = "1.0.140"
 
 #[profile.release]
 #debug = true

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -19,7 +19,7 @@ enum Commands {
     #[command(group(
         ArgGroup::new("advanced_display_group")
         .required(false)
-        .args(["detailed_results","detailed_results_json","parsed_results","raw_bytes"]),
+        .args(["detailed_results","detailed_result_json","parsed_results","raw_bytes"]),
     ))]
     Decode {
         /// Try much harder to detect barcodes.
@@ -40,7 +40,7 @@ enum Commands {
 
         /// Print detailed results data in JSON format
         #[arg(long)]
-        detailed_results_json: bool,
+        detailed_result_json: bool,
 
         /// Print parsed results (exclusive with --detailed-results and --raw-bytes)
         #[arg(long)]
@@ -250,7 +250,7 @@ fn main() {
             allowed_ean_extensions,
             also_inverted,
             detailed_results,
-            detailed_results_json,
+            detailed_result_json,
             parsed_results,
             raw_bytes,
         } => decode_command(
@@ -268,7 +268,7 @@ fn main() {
             allowed_ean_extensions,
             also_inverted,
             detailed_results,
-            detailed_results_json,
+            detailed_result_json,
             parsed_results,
             raw_bytes,
         ),
@@ -335,7 +335,7 @@ fn decode_command(
     allowed_ean_extensions: &Option<Vec<u32>>,
     also_inverted: &Option<bool>,
     detailed_result: &bool,
-    detailed_results_json: &bool,
+    detailed_result_json: &bool,
     parsed_bytes: &bool,
     raw_bytes: &bool,
 ) {
@@ -439,7 +439,7 @@ fn decode_command(
                         print_result(
                             &result,
                             *detailed_result,
-                            *detailed_results_json,
+                            *detailed_result_json,
                             *raw_bytes,
                             *parsed_bytes
                         )
@@ -462,7 +462,7 @@ fn decode_command(
             Ok(result) => {
                 // For JSON (and other machine readable format) don't print anything else to the
                 // stdout.
-                let prefix = if !*detailed_results_json {
+                let prefix = if !*detailed_result_json {
                     "Detection result: \n"
                 } else {
                     ""
@@ -472,7 +472,7 @@ fn decode_command(
                     print_result(
                         &result,
                         *detailed_result,
-                        *detailed_results_json,
+                        *detailed_result_json,
                         *raw_bytes,
                         *parsed_bytes
                     )

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -19,7 +19,7 @@ enum Commands {
     #[command(group(
         ArgGroup::new("advanced_display_group")
         .required(false)
-        .args(["detailed_results","detailed_result_json","parsed_results","raw_bytes"]),
+        .args(["detailed_results","detailed_results_json","parsed_results","raw_bytes"]),
     ))]
     Decode {
         /// Try much harder to detect barcodes.
@@ -40,7 +40,7 @@ enum Commands {
 
         /// Print detailed results data in JSON format
         #[arg(long)]
-        detailed_result_json: bool,
+        detailed_results_json: bool,
 
         /// Print parsed results (exclusive with --detailed-results and --raw-bytes)
         #[arg(long)]
@@ -250,7 +250,7 @@ fn main() {
             allowed_ean_extensions,
             also_inverted,
             detailed_results,
-            detailed_result_json,
+            detailed_results_json,
             parsed_results,
             raw_bytes,
         } => decode_command(
@@ -268,7 +268,7 @@ fn main() {
             allowed_ean_extensions,
             also_inverted,
             detailed_results,
-            detailed_result_json,
+            detailed_results_json,
             parsed_results,
             raw_bytes,
         ),
@@ -335,7 +335,7 @@ fn decode_command(
     allowed_ean_extensions: &Option<Vec<u32>>,
     also_inverted: &Option<bool>,
     detailed_result: &bool,
-    detailed_result_json: &bool,
+    detailed_results_json: &bool,
     parsed_bytes: &bool,
     raw_bytes: &bool,
 ) {
@@ -439,7 +439,7 @@ fn decode_command(
                         print_result(
                             &result,
                             *detailed_result,
-                            *detailed_result_json,
+                            *detailed_results_json,
                             *raw_bytes,
                             *parsed_bytes
                         )
@@ -462,7 +462,7 @@ fn decode_command(
             Ok(result) => {
                 // For JSON (and other machine readable format) don't print anything else to the
                 // stdout.
-                let prefix = if !*detailed_result_json {
+                let prefix = if !*detailed_results_json {
                     "Detection result: \n"
                 } else {
                     ""
@@ -472,7 +472,7 @@ fn decode_command(
                     print_result(
                         &result,
                         *detailed_result,
-                        *detailed_result_json,
+                        *detailed_results_json,
                         *raw_bytes,
                         *parsed_bytes
                     )


### PR DESCRIPTION
Close #64. User can now pass `--detailed-results-json` to print the results in JSON format. 

- Adds a dependency `serde_json` ! 
- Changes code formatting at a few places because I ran `cargo +nightly fmt`. I can revert them back. These changes are both harmless and useless.

The prefix `Detection result: \n` is not printed when `--detailed-results-json` is used. It is to ensure that if another process captures stdout at a successful run, it can assume it to be a valid JSON.


![image](https://github.com/user-attachments/assets/f6e35c36-a377-470e-994d-ad35718ec715)


## Example run

```
Running `/home/dilawar/rxing/target/debug/rxing-cli /home/dilawar/Downloads/3298.png decode --detailed-results-json`
{
  "text": "https://ehr-sample.onrender.com/sample/0003298",
  "rawBytes": [
    104,
    116,
    116,
    112,
    115,
    58,
    47,
    47,
    101,
    104,
    114,
    45,
    115,
    97,
    109,
    112,
    108,
    101,
    46,
    111,
    110,
    114,
    101,
    110,
    100,
    101,
    114,
    46,
    99,
    111,
    109,
    47,
    115,
    97,
    109,
    112,
    108,
    101,
    47,
    48,
    48,
    48,
    51,
    50,
    57,
    56
  ],
  "numBits": 368,
  "resultPoints": [
    {
      "x": 14.202776,
      "y": 14.20277
    },
    {
      "x": 255.11395,
      "y": 14.079432
    },
    {
      "x": 254.94168,
      "y": 254.94171
    },
    {
      "x": 14.079441,
      "y": 255.11395
    }
  ],
  "format": "QR_CODE",
  "resultMetadata": {
    "ERROR_CORRECTION_LEVEL": {
      "ErrorCorrectionLevel": "L"
    },
    "STRUCTURED_APPEND_SEQUENCE": {
      "StructuredAppendSequence": -1
    },
    "SYMBOLOGY_IDENTIFIER": {
      "SymbologyIdentifier": "]Q1"
    },
    "STRUCTURED_APPEND_PARITY": {
      "StructuredAppendParity": -1
    }
  },
  "timestamp": 1750522910447,
  "line_count": 0
}
```
