### PR TITLE
Some memory optimizations

### DIFF
--- a/src/buffered_image_luminance_source.rs
+++ b/src/buffered_image_luminance_source.rs
@@ -91,10 +91,10 @@ impl LuminanceSource for BufferedImageLuminanceSource {
         pixels
     }
 
-    fn get_matrix(&self) -> Vec<u8> {
+    fn get_matrix(&self) -> Cow<'_, [u8]> {
         // if self.height == self.image.height() as usize && self.width == self.image.width() as usize
         // {
-        self.image.as_bytes().to_vec()
+        Cow::Borrowed(self.image.as_bytes())
         // }
         // let skip = self.image.width();
         // let row_skip = 0;

--- a/src/common/adaptive_threshold_binarizer.rs
+++ b/src/common/adaptive_threshold_binarizer.rs
@@ -32,7 +32,7 @@ impl<LS: LuminanceSource> AdaptiveThresholdBinarizer<LS> {
             let Some(buff): Option<ImageBuffer<Luma<u8>, Vec<u8>>> = ImageBuffer::from_vec(
                 self.source.get_width() as u32,
                 self.source.get_height() as u32,
-                self.source.get_matrix(),
+                self.source.get_matrix().into_owned(),
             ) else {
                 return Err(Exceptions::ILLEGAL_ARGUMENT);
             };

--- a/src/common/bit_matrix.rs
+++ b/src/common/bit_matrix.rs
@@ -792,9 +792,9 @@ impl From<&BitMatrix> for image::DynamicImage {
 
         for (x, y, pixel) in pixels.enumerate_pixels_mut() {
             let new_pixel = if value.get(x, y) {
-                image::Rgb([0, 0, 0])
+                image::Luma([0])
             } else {
-                image::Rgb([u8::MAX, u8::MAX, u8::MAX])
+                image::Luma([u8::MAX])
             };
             *pixel = new_pixel
         }

--- a/src/common/hybrid_binarizer.rs
+++ b/src/common/hybrid_binarizer.rs
@@ -174,7 +174,7 @@ impl<LS: LuminanceSource> HybridBinarizer<LS> {
         sub_height: u32,
         width: u32,
         height: u32,
-        black_points: &[Vec<u32>],
+        black_points: &[u32],
         matrix: &mut BitMatrix,
     ) {
         let maxYOffset = height - BLOCK_SIZE as u32;
@@ -192,7 +192,7 @@ impl<LS: LuminanceSource> HybridBinarizer<LS> {
                 let mut sum = 0;
                 for z in -2..=2 {
                     // for (int z = -2; z <= 2; z++) {
-                    let blackRow = &black_points[(top as i32 + z) as usize];
+                    let blackRow = &black_points[((top as i32 + z) as u32 * sub_width) as usize..];
                     sum += blackRow[(left - 2) as usize]
                         + blackRow[(left - 1) as usize]
                         + blackRow[left as usize]
@@ -241,10 +241,10 @@ impl<LS: LuminanceSource> HybridBinarizer<LS> {
         subHeight: u32,
         width: u32,
         height: u32,
-    ) -> Vec<Vec<u32>> {
+    ) -> Vec<u32> {
         let maxYOffset = height as usize - BLOCK_SIZE;
         let maxXOffset = width as usize - BLOCK_SIZE;
-        let mut blackPoints = vec![vec![0; subWidth as usize]; subHeight as usize];
+        let mut blackPoints = vec![0; (subHeight * subWidth) as usize];
         for y in 0..subHeight {
             // for (int y = 0; y < subHeight; y++) {
             let yoffset = u32::min(y << BLOCK_SIZE_POWER, maxYOffset as u32);
@@ -304,17 +304,17 @@ impl<LS: LuminanceSource> HybridBinarizer<LS> {
                         // the boundaries is used for the interior.
 
                         // The (min < bp) is arbitrary but works better than other heuristics that were tried.
-                        let average_neighbor_black_point: u32 = (blackPoints[y as usize - 1]
-                            [x as usize]
-                            + (2 * blackPoints[y as usize][x as usize - 1])
-                            + blackPoints[y as usize - 1][x as usize - 1])
+                        let average_neighbor_black_point: u32 = (blackPoints
+                            [(y as usize - 1) * subWidth as usize + x as usize]
+                            + (2 * blackPoints[y as usize * subWidth as usize + x as usize - 1])
+                            + blackPoints[(y as usize - 1) * subWidth as usize + x as usize - 1])
                             / 4;
                         if (min as u32) < average_neighbor_black_point {
                             average = average_neighbor_black_point;
                         }
                     }
                 }
-                blackPoints[y as usize][x as usize] = average;
+                blackPoints[(y * subWidth + x) as usize] = average;
             }
         }
         blackPoints

--- a/src/common/test_utils.rs
+++ b/src/common/test_utils.rs
@@ -54,8 +54,8 @@ impl LuminanceSource for MockLuminanceSource {
         column
     }
 
-    fn get_matrix(&self) -> Vec<u8> {
-        self.luminances.clone()
+    fn get_matrix(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(&self.luminances)
     }
 
     fn get_width(&self) -> usize {

--- a/src/filtered_image_reader.rs
+++ b/src/filtered_image_reader.rs
@@ -30,7 +30,7 @@ impl<R: Reader> Reader for FilteredImageReader<R> {
     ) -> crate::common::Result<crate::RXingResult> {
         let pyramids = LumImagePyramid::new(
             Luma8LuminanceSource::new(
-                image.get_source().get_matrix(),
+                image.get_source().get_matrix().into_owned(),
                 image.get_source().get_width() as u32,
                 image.get_source().get_height() as u32,
             ),

--- a/src/luma_luma_source.rs
+++ b/src/luma_luma_source.rs
@@ -46,8 +46,8 @@ impl LuminanceSource for Luma8LuminanceSource {
             })
     }
 
-    fn get_matrix(&self) -> Vec<u8> {
-        self.data.clone().into()
+    fn get_matrix(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(&self.data)
     }
 
     fn get_width(&self) -> usize {

--- a/src/luminance_source.rs
+++ b/src/luminance_source.rs
@@ -61,7 +61,7 @@ pub trait LuminanceSource {
      *         larger than width * height bytes on some platforms. Do not modify the contents
      *         of the result.
      */
-    fn get_matrix(&self) -> Vec<u8>;
+    fn get_matrix(&self) -> Cow<'_, [u8]>;
 
     /**
      * @return The width of the bitmap.

--- a/src/planar_yuv_luminance_source.rs
+++ b/src/planar_yuv_luminance_source.rs
@@ -265,7 +265,7 @@ impl LuminanceSource for PlanarYUVLuminanceSource {
         unimplemented!()
     }
 
-    fn get_matrix(&self) -> Vec<u8> {
+    fn get_matrix(&self) -> Cow<'_, [u8]> {
         let width = self.get_width();
         let height = self.get_height();
 
@@ -276,7 +276,7 @@ impl LuminanceSource for PlanarYUVLuminanceSource {
             if self.invert {
                 v = self.invert_block_of_bytes(v);
             }
-            return v;
+            return Cow::Owned(v);
         }
 
         let area = width * height;
@@ -289,7 +289,7 @@ impl LuminanceSource for PlanarYUVLuminanceSource {
             if self.invert {
                 matrix = self.invert_block_of_bytes(matrix);
             }
-            return matrix;
+            return Cow::Owned(matrix);
         }
 
         // Otherwise copy one cropped row at a time.
@@ -304,7 +304,7 @@ impl LuminanceSource for PlanarYUVLuminanceSource {
             matrix = self.invert_block_of_bytes(matrix);
         }
 
-        matrix
+        Cow::Owned(matrix)
     }
 
     fn get_width(&self) -> usize {

--- a/src/rgb_luminance_source.rs
+++ b/src/rgb_luminance_source.rs
@@ -63,11 +63,11 @@ impl LuminanceSource for RGBLuminanceSource {
         unimplemented!()
     }
 
-    fn get_matrix(&self) -> Vec<u8> {
+    fn get_matrix(&self) -> Cow<'_, [u8]> {
         if self.invert {
-            self.invert_block_of_bytes(self.luminances.to_vec())
+            Cow::Owned(self.invert_block_of_bytes(self.luminances.to_vec()))
         } else {
-            self.luminances.to_vec()
+            Cow::Borrowed(&self.luminances)
         }
     }
 

--- a/src/rgb_luminance_source_test_case.rs
+++ b/src/rgb_luminance_source_test_case.rs
@@ -48,16 +48,16 @@ fn testMatrix() {
     let SOURCE = RGBLuminanceSource::new_with_width_height_pixels(3, 3, SRC_DATA.as_ref());
 
     assert_eq!(
-        vec![0x00, 0x7F, 0xFF, 0x3F, 0x7F, 0x3F, 0x3F, 0x7F, 0x3F],
-        SOURCE.get_matrix()
+        &[0x00, 0x7F, 0xFF, 0x3F, 0x7F, 0x3F, 0x3F, 0x7F, 0x3F],
+        &*SOURCE.get_matrix()
     );
     let croppedFullWidth = SOURCE.crop(0, 1, 3, 2).unwrap();
     assert_eq!(
-        vec![0x3F, 0x7F, 0x3F, 0x3F, 0x7F, 0x3F],
-        croppedFullWidth.get_matrix()
+        &[0x3F, 0x7F, 0x3F, 0x3F, 0x7F, 0x3F],
+        &*croppedFullWidth.get_matrix()
     );
     let croppedCorner = SOURCE.crop(1, 1, 2, 2).unwrap();
-    assert_eq!(vec![0x7F, 0x3F, 0x7F, 0x3F], croppedCorner.get_matrix());
+    assert_eq!(&[0x7F, 0x3F, 0x7F, 0x3F], &*croppedCorner.get_matrix());
 }
 
 #[test]

--- a/src/svg_luminance_source.rs
+++ b/src/svg_luminance_source.rs
@@ -16,7 +16,7 @@ impl LuminanceSource for SVGLuminanceSource {
         self.0.get_column(x)
     }
 
-    fn get_matrix(&self) -> Vec<u8> {
+    fn get_matrix(&self) -> Cow<'_, [u8]> {
         self.0.get_matrix()
     }
 


### PR DESCRIPTION
- Fewer Vec clones due to using Cow for luminance source get_matrix
- Improve memory layout of hybrid binarizer black points data
- Use a single channel image when converting BitMatrix to an `image` crate image