### PR TITLE
Disable default features from imageproc dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ default = [
     "image",
     "client_support",
     "image_formats",
+    "rayon",
     "serde",
     "encoding_rs",
     "encoders",
@@ -73,6 +74,10 @@ image_formats = [
     "image/exr",
     "image/ff",
 ]
+
+#/// Enable rayon-based parallelism inside imageproc operations (binarizers, filters).
+#/// Off by default; correctness is unaffected, this only speeds up image processing.
+rayon = ["image", "imageproc/rayon"]
 
 #/// Enable barcode encoders
 encoders = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ uriparse = {version = "0.6", optional = true}
 chrono = { version = "0.4", default-features = false, features = ["clock", "std", "oldtime"] }
 chrono-tz = {version = "0.10", optional = true}
 image = {version = "=0.25.8", optional = true, default-features = false}
-imageproc = {version = "0.25", optional = true}
+imageproc = {version = "0.25", optional = true, default-features = false}
 unicode-segmentation = "1.13"
 codepage-437 = {version = "0.1", optional = true}
 rxing-one-d-proc-derive = {version = "0.9", path ="./crates/one-d-proc-derive", optional = true}

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Please note that currently UPC/EAN Extension 2/5 is supported.
 The following feature flags are available:
 * `image`: Enable features required for image manipulation and reading.
 * `image_formats`: Enabled by default. Compile all `image` crate image format support options.
+* `rayon`: Enabled by default. Turns on `rayon`-based parallelism inside the `imageproc` operations rxing uses (binarizers, filters).
 * `allow_forced_iso_ied_18004_compliance`: Allows the ability to force ISO/IED 18004 compliance. Leave disabled unless specificially needed.
 * `client_support`: Enable the client library. This is used for parsing the result of barcodes.
 * `svg_write`: Enable support for writing SVG files
@@ -66,7 +67,7 @@ The following feature flags are available:
 * `encoding_rs`: Enabled by default. Uses the modern `encoding_rs` crate for high-performance, WHATWG-compliant character encoding support.
 * `legacy_encoding`: Provides the original encoding behavior using the legacy `encoding` crate. Use this if you require exact compatibility with older versions or specific non-standard character mappings.
 
-The default feature set includes the `image`, `client_support`, `image_formats`, and `encoding_rs` features mentioned above.
+The default feature set includes the `image`, `client_support`, `image_formats`, `rayon`, and `encoding_rs` features mentioned above.
 
 ## Incomplete
 The library has only been thurougly tested with the `BufferedImageLuminanceSource` source format. Using any other


### PR DESCRIPTION
...since it's pulling in all image formats (through `image/default`), nullifying the image_formats feature.
This makes rayon optional too, leaving more control to library users.