### PR TITLE
Fix cpp_port FinderPatternSets order

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ svg = {version = "0.18", optional = true}
 resvg = {version = "0.45", optional = true, default-features=false}
 serde = { version = "1", features = ["derive", "rc"], optional = true }
 thiserror = "2.0"
-multimap = {version="0.10", optional = true}
 
 [dev-dependencies]
 java-properties = "2.0"
@@ -101,7 +100,7 @@ aztec = []
 maxicode = []
 
 #//// Enable support for QR Code barcodes
-qrcode = ["dep:multimap"]
+qrcode = []
 
 #//// Enable support for Data Matrix barcodes
 datamatrix = []

--- a/src/qrcode/cpp_port/bitmatrix_parser.rs
+++ b/src/qrcode/cpp_port/bitmatrix_parser.rs
@@ -169,7 +169,7 @@ pub fn ReadQRCodewords(
                     // If we've made a whole byte, save it off
                     bitsRead += 1;
                     if bitsRead % 8 == 0 {
-                        result.push(std::mem::take(&mut currentByte));
+                        result.push(std::mem::take(&mut currentByte) as u8);
                     }
                 }
             }
@@ -182,7 +182,7 @@ pub fn ReadQRCodewords(
         return Err(Exceptions::FORMAT);
     }
 
-    Ok(result.iter().copied().map(|x| x as u8).collect())
+    Ok(result)
 }
 
 pub fn ReadMQRCodewords(
@@ -233,7 +233,7 @@ pub fn ReadMQRCodewords(
                     if bitsRead == 8
                         || (bitsRead == 4 && hasD4mBlock && (result.len()) == d4mBlockIndex - 1)
                     {
-                        result.push(std::mem::take(&mut currentByte));
+                        result.push(std::mem::take(&mut currentByte) as u8);
                         bitsRead = 0;
                     }
                 }
@@ -247,7 +247,7 @@ pub fn ReadMQRCodewords(
         return Err(Exceptions::FORMAT);
     }
 
-    Ok(result.iter().copied().map(|x| x as u8).collect())
+    Ok(result)
 }
 
 pub fn ReadQRCodewordsModel1(
@@ -286,7 +286,7 @@ pub fn ReadQRCodewordsModel1(
                             ),
                     );
                 }
-                result.push(currentByte);
+                result.push(currentByte as u8);
             }
         } else if columns - j <= 4 {
             // vertical symbols on the left side
@@ -309,7 +309,7 @@ pub fn ReadQRCodewordsModel1(
                             ),
                     );
                 }
-                result.push(currentByte);
+                result.push(currentByte as u8);
             }
         } else {
             // horizontal symbols
@@ -342,7 +342,7 @@ pub fn ReadQRCodewordsModel1(
                             ),
                     );
                 }
-                result.push(currentByte);
+                result.push(currentByte as u8);
             }
         }
     }
@@ -352,7 +352,7 @@ pub fn ReadQRCodewordsModel1(
         return Err(Exceptions::FORMAT);
     }
 
-    Ok(result.iter().copied().map(|x| x as u8).collect())
+    Ok(result)
 }
 
 pub fn ReadRMQRCodewords(
@@ -391,7 +391,7 @@ pub fn ReadRMQRCodewords(
                     bitsRead += 1;
                     if bitsRead % 8 == 0 {
                         // if (++bitsRead % 8 == 0){
-                        result.push(currentByte);
+                        result.push(currentByte as u8);
                         currentByte = 0;
                     }
                 }
@@ -405,7 +405,7 @@ pub fn ReadRMQRCodewords(
         return Err(Exceptions::FORMAT);
     }
 
-    Ok(result.iter().copied().map(|x| x as u8).collect())
+    Ok(result)
 }
 
 pub fn ReadCodewords(

--- a/src/qrcode/cpp_port/decoder.rs
+++ b/src/qrcode/cpp_port/decoder.rs
@@ -46,13 +46,12 @@ pub fn CorrectErrors(codewordBytes: &mut [u8], numDataCodewords: u32) -> Result<
 
     // Copy back into array of bytes -- only need to worry about the bytes that were data
     // We don't care about errors in the error-correction codewords
-    codewordBytes[..numDataCodewords as usize].copy_from_slice(
-        &codewordsInts[..numDataCodewords as usize]
-            .iter()
-            .copied()
-            .map(|i| i as u8)
-            .collect::<Vec<u8>>(),
-    );
+    for (dst, &src) in codewordBytes[..numDataCodewords as usize]
+        .iter_mut()
+        .zip(&codewordsInts[..numDataCodewords as usize])
+    {
+        *dst = src as u8;
+    }
     // std::copy_n(codewordsInts.begin(), numDataCodewords, codewordBytes.begin());
 
     Ok(true)

--- a/src/qrcode/cpp_port/detector.rs
+++ b/src/qrcode/cpp_port/detector.rs
@@ -21,7 +21,6 @@ use crate::{
         detector::QRCodeDetectorResult,
     },
 };
-use multimap::MultiMap;
 
 use crate::{
     Point,
@@ -184,7 +183,7 @@ fn spiral(radius: i32) -> impl Iterator<Item = (i32, i32)> {
 pub fn GenerateFinderPatternSets(patterns: &mut FinderPatterns) -> FinderPatternSets {
     patterns.sort_by_key(|b| std::cmp::Reverse(b.size)); // descending: larger patterns first (less likely to be noise)
 
-    let mut sets: MultiMap<String, FinderPatternSet> = MultiMap::new();
+    let mut sets: Vec<(f64, FinderPatternSet)> = Vec::new();
     let squaredDistance = |a: ConcentricPattern, b: ConcentricPattern| {
         // The scaling of the distance by the b/a size ratio is a very coarse compensation for the shortening effect of
         // the camera projection on slanted symbols. The fact that the size of the finder pattern is proportional to the
@@ -312,30 +311,24 @@ pub fn GenerateFinderPatternSets(patterns: &mut FinderPatterns) -> FinderPattern
                     std::mem::swap(&mut a, &mut c);
                 }
 
+                // first order approximation of plausibility (lower = more plausible)
                 let score = distAB + distBC + (distAB - distBC).abs();
-                sets.insert(
-                    score.to_string(),
+                sets.push((
+                    score,
                     FinderPatternSet {
                         bl: *a,
                         tl: *b,
                         tr: *c,
                     },
-                );
+                ));
             }
         }
     }
 
-    // convert from multimap to vector
-    let mut res: FinderPatternSets = Vec::with_capacity(sets.len());
+    // ascending score: most plausible sets first
+    sets.sort_by(|a, b| a.0.total_cmp(&b.0));
 
-    for (_, v) in sets {
-        // for (auto& [d, s] : sets)
-        res.extend(v);
-    }
-
-    res.sort_by_key(|i| i.bl.size);
-
-    res
+    sets.into_iter().map(|(_, s)| s).collect()
 }
 
 pub fn EstimateModuleSize(image: &BitMatrix, a: ConcentricPattern, b: ConcentricPattern) -> f64 {


### PR DESCRIPTION
Fix GenerateFinderPatternSets scores not being used (divergence from c++ code) and remove the multimap from the implementation because it doesn't keep insertion order anyway.
Also includes a couple allocation optimizations in cpp_port.