### PR TITLE
fix(pdf417): bound bitstream parser control operands by the length descriptor

### DIFF
--- a/src/pdf417/decoder/decoded_bit_stream_parser.rs
+++ b/src/pdf417/decoder/decoded_bit_stream_parser.rs
@@ -106,11 +106,71 @@ static EXP900: Lazy<Vec<BigUint>> = Lazy::new(|| {
 
 const NUMBER_OF_SEQUENCE_CODEWORDS: usize = 2;
 
+/// Returns the number of data codewords declared by the Symbol Length Descriptor.
+///
+/// `codewords[0]` declares how many entries of the recovered array are data,
+/// counting the descriptor itself and excluding the error correction codewords
+/// that follow the data in the same array. Every bound in this parser is
+/// expressed against this value, so a control sequence can never read an error
+/// correction codeword as payload and no length arithmetic can underflow when a
+/// stream is truncated.
+fn dataCodewordCount(codewords: &[u32]) -> Result<usize> {
+    let Some(declaredCount) = codewords.first().map(|count| *count as usize) else {
+        return Err(Exceptions::FORMAT);
+    };
+    if declaredCount == 0 || declaredCount > codewords.len() {
+        // The descriptor counts itself, so zero is not a legal declaration, and a
+        // declaration reaching past the recovered array cannot be trusted.
+        return Err(Exceptions::FORMAT);
+    }
+
+    Ok(declaredCount)
+}
+
+/// Reads the operand that a control sequence consumes at `codeIndex`.
+///
+/// The operand has to lie inside the declared data codewords, so a truncated
+/// control sequence becomes a format error instead of an out of range index or a
+/// silent read of the error correction tail.
+fn operandAt(codewords: &[u32], dataCodewords: usize, codeIndex: usize) -> Result<u32> {
+    if codeIndex >= dataCodewords {
+        return Err(Exceptions::FORMAT);
+    }
+
+    codewords.get(codeIndex).copied().ok_or(Exceptions::FORMAT)
+}
+
+/// Skips the `operands` codewords a control sequence consumes without
+/// interpreting them, after proving they lie inside the declared data codewords.
+fn skipOperands(dataCodewords: usize, codeIndex: usize, operands: usize) -> Result<usize> {
+    let next = codeIndex + operands;
+    if next > dataCodewords {
+        return Err(Exceptions::FORMAT);
+    }
+
+    Ok(next)
+}
+
+/// Number of decoded values a text compaction run starting at `codeIndex` can
+/// produce, which is two per remaining data codeword.
+///
+/// A start index already past the declared data codewords means the control
+/// sequence that produced it was truncated, so it is a format error rather than
+/// an underflowing subtraction and an allocation sized from the result.
+fn textCompactionCapacity(dataCodewords: usize, codeIndex: usize) -> Result<usize> {
+    let Some(remaining) = dataCodewords.checked_sub(codeIndex) else {
+        return Err(Exceptions::FORMAT);
+    };
+
+    Ok(remaining * 2)
+}
+
 pub fn decode(codewords: &[u32], ecLevel: &str) -> Result<DecoderRXingResult> {
+    let dataCodewords = dataCodewordCount(codewords)?;
     let mut result = ECIStringBuilder::with_capacity(codewords.len() * 2);
     let mut codeIndex = textCompaction(codewords, 1, &mut result)?;
     let mut resultMetadata = PDF417RXingResultMetadata::default();
-    while codeIndex < codewords[0] as usize {
+    while codeIndex < dataCodewords {
         let code = codewords[codeIndex];
         codeIndex += 1;
         match code {
@@ -121,25 +181,26 @@ pub fn decode(codewords: &[u32], ecLevel: &str) -> Result<DecoderRXingResult> {
                 codeIndex = byteCompaction(code, codewords, codeIndex, &mut result)?
             }
             MODE_SHIFT_TO_BYTE_COMPACTION_MODE => {
-                result.append_char(char::from_u32(codewords[codeIndex]).ok_or(Exceptions::PARSE)?);
+                let shifted = operandAt(codewords, dataCodewords, codeIndex)?;
+                result.append_char(char::from_u32(shifted).ok_or(Exceptions::PARSE)?);
                 codeIndex += 1;
             }
             NUMERIC_COMPACTION_MODE_LATCH => {
                 codeIndex = numericCompaction(codewords, codeIndex, &mut result)?
             }
             ECI_CHARSET => {
-                result.append_eci(Eci::from(codewords[codeIndex]));
+                result.append_eci(Eci::from(operandAt(codewords, dataCodewords, codeIndex)?));
                 codeIndex += 1;
             }
             ECI_GENERAL_PURPOSE =>
             // Can't do anything with generic ECI; skip its 2 characters
             {
-                codeIndex += 2
+                codeIndex = skipOperands(dataCodewords, codeIndex, 2)?
             }
             ECI_USER_DEFINED =>
             // Can't do anything with user ECI; skip its 1 character
             {
-                codeIndex += 1
+                codeIndex = skipOperands(dataCodewords, codeIndex, 1)?
             }
             BEGIN_MACRO_PDF417_CONTROL_BLOCK => {
                 codeIndex = decodeMacroBlock(codewords, codeIndex, &mut resultMetadata)?
@@ -181,8 +242,9 @@ pub fn decodeMacroBlock(
     codeIndex: usize,
     resultMetadata: &mut PDF417RXingResultMetadata,
 ) -> Result<usize> {
+    let dataCodewords = dataCodewordCount(codewords)?;
     let mut codeIndex = codeIndex;
-    if codeIndex + NUMBER_OF_SEQUENCE_CODEWORDS > codewords[0] as usize {
+    if codeIndex + NUMBER_OF_SEQUENCE_CODEWORDS > dataCodewords {
         // we must have at least two bytes left for the segment index
         return Err(Exceptions::FORMAT);
     }
@@ -191,7 +253,7 @@ pub fn decodeMacroBlock(
         .iter_mut()
         .take(NUMBER_OF_SEQUENCE_CODEWORDS)
     {
-        *seq = codewords[codeIndex];
+        *seq = operandAt(codewords, dataCodewords, codeIndex)?;
         codeIndex += 1;
     }
     let segmentIndexString =
@@ -209,8 +271,7 @@ pub fn decodeMacroBlock(
     // (See ISO/IEC 15438:2015 Annex H.6) and preserves all info, but some generators (e.g. TEC-IT) write
     // the fileId using text compaction, so in those cases the fileId will appear mangled.
     let mut fileId = String::new();
-    while codeIndex < codewords[0] as usize
-        && codeIndex < codewords.len()
+    while codeIndex < dataCodewords
         && codewords[codeIndex] != MACRO_PDF417_TERMINATOR
         && codewords[codeIndex] != BEGIN_MACRO_PDF417_OPTIONAL_FIELD
     {
@@ -224,15 +285,18 @@ pub fn decodeMacroBlock(
     resultMetadata.setFileId(fileId);
 
     let mut optionalFieldsStart = -1_isize;
-    if codewords[codeIndex] == BEGIN_MACRO_PDF417_OPTIONAL_FIELD {
+    // A file ID that ends exactly at the declared data boundary is not followed
+    // by an optional field latch, whatever the error correction tail happens to
+    // hold there.
+    if codeIndex < dataCodewords && codewords[codeIndex] == BEGIN_MACRO_PDF417_OPTIONAL_FIELD {
         optionalFieldsStart = codeIndex as isize + 1;
     }
 
-    while codeIndex < codewords[0] as usize {
+    while codeIndex < dataCodewords {
         match codewords[codeIndex] {
             BEGIN_MACRO_PDF417_OPTIONAL_FIELD => {
                 codeIndex += 1;
-                match codewords[codeIndex] {
+                match operandAt(codewords, dataCodewords, codeIndex)? {
                     MACRO_PDF417_OPTIONAL_FIELD_FILE_NAME => {
                         let mut fileName = ECIStringBuilder::default();
                         codeIndex = textCompaction(codewords, codeIndex + 1, &mut fileName)?;
@@ -293,16 +357,22 @@ pub fn decodeMacroBlock(
 
     // copy optional fields to additional options
     if optionalFieldsStart != -1 {
-        let mut optionalFieldsLength = codeIndex - optionalFieldsStart as usize;
+        let optionalFieldsStart = optionalFieldsStart as usize;
+        let Some(mut optionalFieldsLength) = codeIndex.checked_sub(optionalFieldsStart) else {
+            return Err(Exceptions::FORMAT);
+        };
         if resultMetadata.isLastSegment() {
             // do not include terminator
-            optionalFieldsLength -= 1;
+            let Some(withoutTerminator) = optionalFieldsLength.checked_sub(1) else {
+                return Err(Exceptions::FORMAT);
+            };
+            optionalFieldsLength = withoutTerminator;
         }
 
+        // `codeIndex` never passed the declared data boundary, so this range
+        // holds data codewords only.
         resultMetadata.setOptionalData(
-            codewords[optionalFieldsStart as usize
-                ..(optionalFieldsStart + optionalFieldsLength as isize) as usize]
-                .to_vec(),
+            codewords[optionalFieldsStart..optionalFieldsStart + optionalFieldsLength].to_vec(),
         );
     }
 
@@ -324,17 +394,19 @@ fn textCompaction(
     codeIndex: usize,
     result: &mut ECIStringBuilder,
 ) -> Result<usize> {
+    let dataCodewords = dataCodewordCount(codewords)?;
     let mut codeIndex = codeIndex;
     // 2 character per codeword
-    let mut textCompactionData = vec![0; (codewords[0] as usize - codeIndex) * 2];
+    let capacity = textCompactionCapacity(dataCodewords, codeIndex)?;
+    let mut textCompactionData = vec![0; capacity];
     // Used to hold the byte compaction value if there is a mode shift
-    let mut byteCompactionData = vec![0; (codewords[0] as usize - codeIndex) * 2];
+    let mut byteCompactionData = vec![0; capacity];
 
     let mut index = 0;
     let mut end = false;
     let mut subMode = Mode::Alpha;
 
-    while (codeIndex < codewords[0] as usize) && !end {
+    while (codeIndex < dataCodewords) && !end {
         let mut code = codewords[codeIndex];
         codeIndex += 1;
 
@@ -366,12 +438,15 @@ fn textCompaction(
                 // of the Text Compaction Mode:: Codeword 913 is only available
                 // in Text Compaction mode; its use is described in 5.4.2.4.
                 textCompactionData[index] = MODE_SHIFT_TO_BYTE_COMPACTION_MODE;
-                code = codewords[codeIndex];
+                code = operandAt(codewords, dataCodewords, codeIndex)?;
                 codeIndex += 1;
                 byteCompactionData[index] = code;
                 index += 1;
             }
             ECI_CHARSET => {
+                // Read the charset operand before flushing, so a truncated
+                // sequence fails without having appended anything.
+                let charset = operandAt(codewords, dataCodewords, codeIndex)?;
                 subMode = decodeTextCompaction(
                     &textCompactionData,
                     &byteCompactionData,
@@ -380,10 +455,11 @@ fn textCompaction(
                     subMode,
                 )
                 .ok_or(Exceptions::ILLEGAL_STATE)?;
-                result.append_eci(Eci::from(codewords[codeIndex]));
+                result.append_eci(Eci::from(charset));
                 codeIndex += 1;
-                textCompactionData = vec![0; (codewords[0] as usize - codeIndex) * 2];
-                byteCompactionData = vec![0; (codewords[0] as usize - codeIndex) * 2];
+                let capacity = textCompactionCapacity(dataCodewords, codeIndex)?;
+                textCompactionData = vec![0; capacity];
+                byteCompactionData = vec![0; capacity];
                 index = 0;
             }
             _ => {}
@@ -602,19 +678,19 @@ fn byteCompaction(
     codeIndex: usize,
     result: &mut ECIStringBuilder,
 ) -> Result<usize> {
+    let dataCodewords = dataCodewordCount(codewords)?;
     let mut end = false;
     let mut codeIndex = codeIndex;
 
-    while codeIndex < codewords[0] as usize && !end {
+    while codeIndex < dataCodewords && !end {
         //handle leading ECIs
-        while codeIndex < codewords[0] as usize && codewords[codeIndex] == ECI_CHARSET {
-            codeIndex += 1;
-            result.append_eci(Eci::from(codewords[codeIndex]));
-            codeIndex += 1;
+        while codeIndex < dataCodewords && codewords[codeIndex] == ECI_CHARSET {
+            let charset = operandAt(codewords, dataCodewords, codeIndex + 1)?;
+            codeIndex += 2;
+            result.append_eci(Eci::from(charset));
         }
 
-        if codeIndex >= codewords[0] as usize || codewords[codeIndex] >= TEXT_COMPACTION_MODE_LATCH
-        {
+        if codeIndex >= dataCodewords || codewords[codeIndex] >= TEXT_COMPACTION_MODE_LATCH {
             end = true;
         } else {
             //decode one block of 5 codewords to 6 bytes
@@ -625,7 +701,7 @@ fn byteCompaction(
                 codeIndex += 1;
                 count += 1;
                 if !(count < 5
-                    && codeIndex < codewords[0] as usize
+                    && codeIndex < dataCodewords
                     && codewords[codeIndex] < TEXT_COMPACTION_MODE_LATCH)
                 {
                     break;
@@ -633,7 +709,7 @@ fn byteCompaction(
             }
             if count == 5
                 && (mode == BYTE_COMPACTION_MODE_LATCH_6
-                    || codeIndex < codewords[0] as usize
+                    || codeIndex < dataCodewords
                         && codewords[codeIndex] < TEXT_COMPACTION_MODE_LATCH)
             {
                 for i in 0..6 {
@@ -641,13 +717,17 @@ fn byteCompaction(
                 }
             } else {
                 codeIndex -= count;
-                while (codeIndex < codewords[0] as usize) && !end {
+                while (codeIndex < dataCodewords) && !end {
                     let code = codewords[codeIndex];
                     codeIndex += 1;
                     if code < TEXT_COMPACTION_MODE_LATCH {
                         result.append_byte(code as u8);
                     } else if code == ECI_CHARSET {
-                        result.append_eci(Eci::from(codewords[codeIndex]));
+                        result.append_eci(Eci::from(operandAt(
+                            codewords,
+                            dataCodewords,
+                            codeIndex,
+                        )?));
                         codeIndex += 1;
                     } else {
                         codeIndex -= 1;
@@ -673,16 +753,17 @@ fn numericCompaction(
     codeIndex: usize,
     result: &mut ECIStringBuilder,
 ) -> Result<usize> {
+    let dataCodewords = dataCodewordCount(codewords)?;
     let mut count = 0;
     let mut end = false;
     let mut codeIndex = codeIndex;
 
     let mut numericCodewords = [0; MAX_NUMERIC_CODEWORDS];
 
-    while codeIndex < codewords[0] as usize && !end {
+    while codeIndex < dataCodewords && !end {
         let code = codewords[codeIndex];
         codeIndex += 1;
-        if codeIndex == codewords[0] as usize {
+        if codeIndex == dataCodewords {
             end = true;
         }
         match code {

--- a/src/pdf417/decoder/pdf_417_decoder_test_case.rs
+++ b/src/pdf417/decoder/pdf_417_decoder_test_case.rs
@@ -17,6 +17,9 @@
 
 use java_rand;
 
+use std::sync::Arc;
+
+use crate::Exceptions;
 use crate::common::CharacterSet;
 use crate::pdf417::PDF417RXingResultMetadata;
 use crate::pdf417::decoder::decoded_bit_stream_parser;
@@ -175,28 +178,242 @@ fn testSampleWithMacroTerminatorOnly() {
 }
 
 #[test]
-#[should_panic]
 fn testSampleWithBadSequenceIndexMacro() {
     let sampleCodes = [3_u32, 928, 222, 0];
     let mut resultMetadata = PDF417RXingResultMetadata::default();
-    decoded_bit_stream_parser::decodeMacroBlock(&sampleCodes, 2, &mut resultMetadata)
-        .expect("decode");
+    assert_eq!(
+        Err(Exceptions::FORMAT),
+        decoded_bit_stream_parser::decodeMacroBlock(&sampleCodes, 2, &mut resultMetadata),
+        "a macro block truncated before its two segment index codewords is a format error"
+    );
 }
 
 #[test]
-#[should_panic]
 fn testSampleWithNoFileIdMacro() {
     let sampleCodes = [4_u32, 928, 222, 198, 0];
     let mut resultMetadata = PDF417RXingResultMetadata::default();
-    decoded_bit_stream_parser::decodeMacroBlock(&sampleCodes, 2, &mut resultMetadata)
-        .expect("decode");
+    assert_eq!(
+        Err(Exceptions::FORMAT),
+        decoded_bit_stream_parser::decodeMacroBlock(&sampleCodes, 2, &mut resultMetadata),
+        "at least one file ID codeword is required (Annex H.2)"
+    );
 }
 
 #[test]
-#[should_panic]
 fn testSampleWithNoDataNoMacro() {
     let sampleCodes = [3_u32, 899, 899, 0];
-    decoded_bit_stream_parser::decode(&sampleCodes, "0").expect("decode");
+    assert_eq!(
+        Err(Exceptions::FORMAT),
+        decodeOutcome(&sampleCodes),
+        "a symbol carrying neither data nor a macro block is a format error"
+    );
+}
+
+/// Everything a decoded symbol carries, in a comparable form. `DecoderRXingResult`
+/// has neither `Debug` nor `PartialEq`, and its error correction level and
+/// erasure counts are not set by the bitstream parser.
+type DecodedOutcome = (String, Option<Arc<PDF417RXingResultMetadata>>);
+
+fn decodeOutcome(codewords: &[u32]) -> Result<DecodedOutcome, Exceptions> {
+    decoded_bit_stream_parser::decode(codewords, "0").map(|result| {
+        let metadata = result
+            .getOther()
+            .and_then(|other| other.downcast::<PDF417RXingResultMetadata>().ok());
+
+        (result.getText().to_owned(), metadata)
+    })
+}
+
+/// The Symbol Length Descriptor, not the length of the recovered array, is the
+/// data boundary: the codewords after it are error correction codewords. Decoding
+/// a symbol together with that tail therefore has to give the same answer as
+/// decoding the declared data codewords on their own. Any difference means a
+/// control sequence read an error correction codeword as payload.
+fn assertErrorCorrectionTailIsNotPayload(codewords: &[u32]) {
+    let declaredCount = codewords[0] as usize;
+    assert!(
+        declaredCount <= codewords.len(),
+        "test vector declares more data codewords than it has"
+    );
+
+    assert_eq!(
+        decodeOutcome(&codewords[..declaredCount]),
+        decodeOutcome(codewords),
+        "the error correction tail changed the outcome of {codewords:?}"
+    );
+}
+
+/// A Symbol Length Descriptor that is absent, zero, or larger than the recovered
+/// array cannot be used as a bound, so it has to be rejected before any length
+/// arithmetic. Zero in particular used to underflow the text compaction buffer
+/// length and size an allocation from the result.
+#[test]
+fn testUnusableSymbolLengthDescriptor() {
+    for sampleCodes in [vec![], vec![0_u32, 477, 477], vec![9_u32, 477]] {
+        assert_eq!(
+            Err(Exceptions::FORMAT),
+            decodeOutcome(&sampleCodes),
+            "{sampleCodes:?} declares an unusable data codeword count"
+        );
+    }
+}
+
+/// Annex H.6's example ends its file ID on the last data codeword. That used to
+/// need a trailing dummy codeword because the optional field check read one past
+/// the boundary; the check is now bounded, so the symbol decodes on its own.
+#[test]
+fn testMacroFileIdEndingAtDataBoundary() {
+    let sampleCodes = [7_u32, 928, 111, 100, 100, 200, 300];
+    let mut resultMetadata = PDF417RXingResultMetadata::default();
+
+    decoded_bit_stream_parser::decodeMacroBlock(&sampleCodes, 2, &mut resultMetadata)
+        .expect("decode");
+
+    assert_eq!(0, resultMetadata.getSegmentIndex());
+    assert_eq!("100200300", resultMetadata.getFileId());
+    assert!(!resultMetadata.isLastSegment());
+    assert!(resultMetadata.getOptionalData().is_empty());
+
+    // An error correction codeword that happens to hold the optional field latch
+    // is still an error correction codeword. Reading it used to underflow the
+    // optional field length and index out of range.
+    let withTail = [7_u32, 928, 111, 100, 100, 200, 300, 923];
+    let mut tailMetadata = PDF417RXingResultMetadata::default();
+
+    decoded_bit_stream_parser::decodeMacroBlock(&withTail, 2, &mut tailMetadata).expect("decode");
+
+    assert_eq!(resultMetadata, tailMetadata);
+    assertErrorCorrectionTailIsNotPayload(&withTail);
+}
+
+/// An optional field latch on the last data codeword has no identifier, and an
+/// identifier on the last data codeword has no payload. Both used to index past
+/// the boundary, the first into the error correction tail and from there into a
+/// text compaction length that underflowed.
+#[test]
+fn testTruncatedMacroOptionalField() {
+    let truncatedVectors: [&[u32]; 4] = [
+        // latch is the last data codeword, nothing follows it at all
+        &[8, 928, 111, 100, 100, 200, 300, 923],
+        // latch is the last data codeword, an error correction codeword follows
+        &[8, 928, 111, 100, 100, 200, 300, 923, 0, 1000],
+        // segment count identifier is the last data codeword, payload is missing
+        &[9, 928, 111, 100, 100, 200, 300, 923, 1, 1000],
+        // identifier is not one of the seven defined optional fields
+        &[9, 928, 111, 100, 100, 200, 300, 923, 7, 1000],
+    ];
+
+    for sampleCodes in truncatedVectors {
+        let mut resultMetadata = PDF417RXingResultMetadata::default();
+        assert_eq!(
+            Err(Exceptions::FORMAT),
+            decoded_bit_stream_parser::decodeMacroBlock(sampleCodes, 2, &mut resultMetadata),
+            "{sampleCodes:?} has a truncated or undefined optional field"
+        );
+        assertErrorCorrectionTailIsNotPayload(sampleCodes);
+    }
+}
+
+/// A text optional field whose payload starts exactly at the declared boundary is
+/// empty rather than truncated, so it decodes with an empty value. What it must
+/// not do is continue into the error correction tail.
+#[test]
+fn testMacroOptionalFieldPayloadEndingAtDataBoundary() {
+    let sampleCodes: [u32; 9] = [9, 928, 111, 100, 100, 200, 300, 923, 0];
+    let mut resultMetadata = PDF417RXingResultMetadata::default();
+
+    assert_eq!(
+        Ok(9),
+        decoded_bit_stream_parser::decodeMacroBlock(&sampleCodes, 2, &mut resultMetadata)
+    );
+    assert_eq!("100200300", resultMetadata.getFileId());
+    assert!(resultMetadata.getFileName().is_empty());
+    assert_eq!(vec![0_u32], resultMetadata.getOptionalData().to_vec());
+
+    let withTail: [u32; 12] = [9, 928, 111, 100, 100, 200, 300, 923, 0, 477, 477, 1000];
+    let mut tailMetadata = PDF417RXingResultMetadata::default();
+
+    assert_eq!(
+        Ok(9),
+        decoded_bit_stream_parser::decodeMacroBlock(&withTail, 2, &mut tailMetadata)
+    );
+    assert_eq!(
+        resultMetadata, tailMetadata,
+        "the empty file name must not absorb error correction codewords"
+    );
+    assertErrorCorrectionTailIsNotPayload(&withTail);
+}
+
+/// Mode Shift to Byte Compaction (913) consumes the following codeword. On the
+/// last data codeword it has no operand: it used to index past the boundary, or
+/// silently promote an error correction codeword to a decoded character.
+#[test]
+fn testTruncatedModeShiftToByteCompaction() {
+    let truncatedVectors: [&[u32]; 4] = [
+        // inside a text compaction run, with and without a tail to misread
+        &[3, 477, 913],
+        &[3, 477, 913, 1000, 1000],
+        // as a control codeword of the symbol itself
+        &[4, 901, 100, 913],
+        &[4, 901, 100, 913, 1000],
+    ];
+
+    for sampleCodes in truncatedVectors {
+        assert_eq!(
+            Err(Exceptions::FORMAT),
+            decodeOutcome(sampleCodes),
+            "{sampleCodes:?} shifts to byte compaction without an operand"
+        );
+        assertErrorCorrectionTailIsNotPayload(sampleCodes);
+    }
+}
+
+/// The ECI control codewords consume one or two following codewords. On the last
+/// data codewords they have no operands: the charset form used to index past the
+/// boundary and then underflow the text compaction buffer length, and the
+/// general purpose and user defined forms used to skip operands that do not exist.
+#[test]
+fn testTruncatedEciControlSequence() {
+    let truncatedVectors: [&[u32]; 8] = [
+        // charset ECI inside a text compaction run
+        &[3, 477, 927],
+        &[3, 477, 927, 1000, 1000],
+        // charset ECI leading a byte compaction run
+        &[3, 901, 927],
+        // charset ECI inside a byte compaction run
+        &[5, 901, 100, 101, 927],
+        &[5, 901, 100, 101, 927, 1000],
+        // charset ECI as a control codeword of the symbol itself
+        &[4, 902, 100, 927],
+        // general purpose ECI needs two operands, user defined ECI needs one
+        &[4, 901, 100, 926, 1000, 1000],
+        &[4, 901, 100, 925, 1000],
+    ];
+
+    for sampleCodes in truncatedVectors {
+        assert_eq!(
+            Err(Exceptions::FORMAT),
+            decodeOutcome(sampleCodes),
+            "{sampleCodes:?} opens an ECI sequence without its operands"
+        );
+        assertErrorCorrectionTailIsNotPayload(sampleCodes);
+    }
+}
+
+/// The standard samples carry sentinel codewords past their declared boundary,
+/// so they are also evidence that a valid symbol ignores its error correction
+/// tail rather than merely tolerating it.
+#[test]
+fn testValidSamplesIgnoreTheErrorCorrectionTail() {
+    assertErrorCorrectionTailIsNotPayload(&[
+        20, 928, 111, 100, 17, 53, 923, 1, 111, 104, 923, 3, 64, 416, 34, 923, 4, 258, 446, 67,
+        1000, 1000, 1000,
+    ]);
+    assertErrorCorrectionTailIsNotPayload(&[
+        11, 928, 111, 103, 17, 53, 923, 1, 111, 104, 922, 1000, 1000, 1000,
+    ]);
+    assertErrorCorrectionTailIsNotPayload(&[7, 928, 111, 100, 100, 200, 300, 0]);
+    assertErrorCorrectionTailIsNotPayload(&[5, 927, 4, 913, 200, 1000, 1000]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

The PDF417 bitstream parser uses two different bounds. Most loops stop at `codewords[0]`, the Symbol Length Descriptor, which is correct — everything after the declared data codewords is error correction data. But several control sequences index the codeword array directly, with no check at all.

`pdf_417_scanning_decoder::decodeCodewords` calls `correctErrors` *before* `verifyCodewordCount` and before parsing, so a malformed symbol whose error correction is valid reaches the parser intact and can drive those unchecked transitions. `verifyCodewordCount` also rewrites a zero descriptor to `len - numECCodewords`, so the error correction tail inside the slice is expected and normal.

Two consequences, both reachable from image input:

1. **Panics.** Out-of-bounds indexing, `usize` subtraction underflow, and an allocation sized from the underflowed value.
2. **Silent payload corruption.** When the array happens to be long enough, a truncated control sequence takes its operand from the error correction tail and the decoded text or ECI reflects error correction codewords.

## Measured baseline on v0.9.2

Harness calls `decoded_bit_stream_parser::decode` (or `decodeMacroBlock`) per vector under `catch_unwind`, `default-features = false, features = ["decoders", "pdf417", "encoding_rs"]`.

```
rxing 0.9.2 baseline, profile debug
empty slice                                    [] -> PANIC: index out of bounds: the len is 0 but the index is 0
zero length descriptor                         [0, 477, 477] -> PANIC: attempt to subtract with overflow
descriptor past array                          [9, 477] -> PANIC: index out of bounds: the len is 2 but the index is 2
macro file id at boundary, latch in ec tail    [7, 928, 111, 100, 100, 200, 300, 923] -> PANIC: attempt to subtract with overflow
macro optional field latch at boundary         [8, 928, 111, 100, 100, 200, 300, 923] -> PANIC: index out of bounds: the len is 8 but the index is 8
macro optional field identifier in ec tail     [8, 928, 111, 100, 100, 200, 300, 923, 0, 1000] -> PANIC: attempt to subtract with overflow
mode shift 913 at final data codeword          [3, 477, 913] -> PANIC: index out of bounds: the len is 3 but the index is 3
mode shift 913 operand in ec tail              [3, 477, 913, 1000, 1000] -> Ok(text "P\u{3e8}", default metadata)
outer mode shift 913 at boundary               [4, 901, 100, 913] -> PANIC: index out of bounds: the len is 4 but the index is 4
outer mode shift 913 operand in ec tail        [4, 901, 100, 913, 1000] -> Ok(text "d\u{3e8}", default metadata)
charset eci 927 at final data codeword         [3, 477, 927] -> PANIC: index out of bounds: the len is 3 but the index is 3
charset eci 927 operand in ec tail             [3, 477, 927, 1000, 1000] -> PANIC: attempt to subtract with overflow
byte compaction leading eci at boundary        [3, 901, 927] -> PANIC: index out of bounds: the len is 3 but the index is 3
byte compaction inner eci at boundary          [5, 901, 100, 101, 927] -> PANIC: index out of bounds: the len is 5 but the index is 5
byte compaction inner eci operand in ec tail   [5, 901, 100, 101, 927, 1000] -> Ok(text "de", default metadata)
outer charset eci at boundary                  [4, 902, 100, 927] -> PANIC: index out of bounds: the len is 4 but the index is 4
outer charset eci operand in ec tail           [4, 902, 100, 927, 1000] -> Ok(text "00", default metadata)
general purpose eci without operands           [4, 901, 100, 926, 1000, 1000] -> Ok(text "d", default metadata)
user defined eci without operand               [4, 901, 100, 925, 1000] -> Ok(text "d", default metadata)
panicking cases: 13/19
```

Release profile is the same 13 panics, with the underflow surfacing where the value is consumed:

```
zero length descriptor                         [0, 477, 477] -> PANIC: capacity overflow
macro file id at boundary, latch in ec tail    [7, 928, 111, 100, 100, 200, 300, 923] -> PANIC: slice index starts at 8 but ends at 7
macro optional field identifier in ec tail     [8, 928, 111, 100, 100, 200, 300, 923, 0, 1000] -> PANIC: capacity overflow
charset eci 927 operand in ec tail             [3, 477, 927, 1000, 1000] -> PANIC: capacity overflow
```

The six non-panicking rows are the corruption case. `[3, 477, 913, 1000, 1000]` declares three data codewords, so `1000` is error correction data — yet `U+03E8` appears in the decoded text. Decoding `[3, 477, 913]` alone panics, so that character comes only from the tail.

## Defects

- `decode`: `codewords[0]` on an empty slice; `textCompaction(codewords, 1, ..)` computes `codewords[0] - 1` for the buffer length, so a zero descriptor underflows and the result sizes a `vec!`.
- `decode`: `MODE_SHIFT_TO_BYTE_COMPACTION_MODE` (913) and `ECI_CHARSET` (927) read `codewords[codeIndex]` unconditionally.
- `decode`: `ECI_GENERAL_PURPOSE` (926) and `ECI_USER_DEFINED` (925) advance past operands without checking they exist.
- `decodeMacroBlock`: `if codewords[codeIndex] == BEGIN_MACRO_PDF417_OPTIONAL_FIELD` after the file-ID loop has no bound. This is the read `testStandardSample3` works around with *"Final dummy ECC codeword required to avoid ArrayIndexOutOfBounds"*. If that codeword is `923`, `optionalFieldsStart` is set past `codeIndex` and `codeIndex - optionalFieldsStart` underflows.
- `decodeMacroBlock`: the optional-field latch reads its field identifier unconditionally, then calls `textCompaction(codewords, codeIndex + 1, ..)`, which underflows the buffer length when the identifier came from the tail.
- `decodeMacroBlock`: `optionalFieldsLength -= 1` is unchecked.
- `textCompaction`: both buffer lengths use `codewords[0] as usize - codeIndex`; the 913 and 927 arms read operands unconditionally, and the 927 arm reallocates from the same unchecked subtraction after advancing.
- `byteCompaction`: the leading-ECI loop and the inner `code == ECI_CHARSET` branch read operands unconditionally.

## Fix

Express every bound as the declared data-codeword count:

- `dataCodewordCount` validates the descriptor once per entry point; absent, zero, or larger than the slice is `Exceptions::FORMAT`. `verifyCodewordCount` already guarantees `1..=len` for the scanning-decoder path, so this only constrains direct callers.
- `operandAt` reads a control operand only from inside the declared range.
- `skipOperands` proves skipped operands exist before advancing.
- `textCompactionCapacity` uses `checked_sub`, so no buffer length is ever derived from an underflow.

The optional-field check after the file-ID loop is now bounded, and the optional-field copy uses checked subtraction.

Nothing else changes: no valid-symbol semantics, no error-correction algorithms, no character-set behaviour, no detector behaviour, no symbology support. The now-redundant `codeIndex < codewords.len()` in the file-ID loop is dropped because `dataCodewordCount <= codewords.len()` already holds, and keeping two different bounds side by side is what caused this bug class.

## Tests

`cargo test --release`: **629 lib tests + every blackbox suite pass, 0 failed.** Annex H standard samples, ECI suites, permutation suites, `testBinaryData`, and the PDF417 blackbox suites are unchanged. `cargo clippy --lib --all-targets` reports the same 89 warnings as the unpatched tag.

`testStandardSample1`/`Sample2` already carry `1000, 1000, 1000` past their declared boundary with the comment *"we should never reach these"*. That is now asserted rather than assumed.

Three existing tests were `#[should_panic]`, which cannot distinguish a returned error from a crash — exactly the property at issue — so they now assert `Err(Exceptions::FORMAT)`:

- `testSampleWithBadSequenceIndexMacro`
- `testSampleWithNoFileIdMacro`
- `testSampleWithNoDataNoMacro`

New tests:

- `testUnusableSymbolLengthDescriptor`
- `testMacroFileIdEndingAtDataBoundary` — also shows the dummy codeword `testStandardSample3` needs is no longer required
- `testTruncatedMacroOptionalField`
- `testMacroOptionalFieldPayloadEndingAtDataBoundary`
- `testTruncatedModeShiftToByteCompaction`
- `testTruncatedEciControlSequence`
- `testValidSamplesIgnoreTheErrorCorrectionTail`

Each also asserts the general property via `assertErrorCorrectionTailIsNotPayload`: decoding a vector together with its error correction tail must equal decoding `&codewords[..codewords[0]]` alone. That fails for *any* read past the boundary, not only for the reads a specific assertion anticipated.

## Notes

Based exactly on `v0.9.2` so it can be cherry-picked onto `main`; happy to rebase or split the test-only changes if you prefer.

`catch_unwind` is not a viable mitigation for downstream users on `wasm32` or with `panic = "abort"`, which is why this is proposed as a parser fix rather than a caller-side guard.

*AI-assisted development disclosure*: This bug was discovered while working on an external project that depends on rxing. An AI coding assistant produced the initial fix for our local build. Since the issue was in the upstream library, I reproduced and tested it independently, manually reviewed and cleaned up the patch, performed the relevant hygiene checks, and submitted it upstream. The final PR was reviewed and submitted by me.
